### PR TITLE
Add minimal text adventure engine and sample plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# herrschaftderasche
+# Herrschaft der Asche
+
+Ein einfaches Textadventure-Projekt. Dieses Repository enthält eine kleine Engine und eine Beispielwelt, die aus YAML-Daten geladen wird.
+
+## Ausführen
+
+```bash
+python game/main.py
+```
+
+Während des Spiels können Befehle wie `gehe wald` oder `gehe hütte` eingegeben werden. Mit `quit` wird das Spiel beendet.

--- a/data/plot.md
+++ b/data/plot.md
@@ -1,0 +1,3 @@
+# Einfacher Plot
+
+Du wachst in einer kleinen Hütte im Wald auf. Draußen hörst du den Wind in den Bäumen. Dein Ziel ist es, den Weg aus dem Wald zu finden.

--- a/data/world.yaml
+++ b/data/world.yaml
@@ -1,0 +1,10 @@
+rooms:
+  hut:
+    description: "Du befindest dich in einer kleinen Hütte. Eine Tür führt nach draußen in den Wald."
+    exits:
+      wald: forest
+  forest:
+    description: "Du stehst auf einer Lichtung im Wald. Zurück geht es in die Hütte."
+    exits:
+      hütte: hut
+start: hut

--- a/engine/__init__.py
+++ b/engine/__init__.py
@@ -1,0 +1,1 @@
+"""Basic engine package for text adventure."""

--- a/engine/game.py
+++ b/engine/game.py
@@ -1,0 +1,23 @@
+"""Core game loop."""
+
+from engine import io, parser, world, llm
+
+
+def run(world_data_path: str) -> None:
+    w = world.World.from_file(world_data_path)
+    io.output(w.describe_current())
+    while True:
+        command = io.get_input()
+        command = llm.interpret(command)
+        command = parser.parse(command)
+        if command in {"quit", "exit"}:
+            io.output("Auf Wiedersehen!")
+            break
+        if command.startswith("gehe "):
+            direction = command.split(" ", 1)[1]
+            if w.move(direction):
+                io.output(w.describe_current())
+            else:
+                io.output("Dort kannst du nicht hin.")
+        else:
+            io.output("Das habe ich nicht verstanden.")

--- a/engine/io.py
+++ b/engine/io.py
@@ -1,0 +1,7 @@
+"""Simple input and output helpers."""
+
+def get_input(prompt: str = "> ") -> str:
+    return input(prompt)
+
+def output(text: str) -> None:
+    print(text)

--- a/engine/llm.py
+++ b/engine/llm.py
@@ -1,0 +1,5 @@
+"""Placeholder for LLM integration via ollama."""
+
+def interpret(command: str) -> str:
+    """For now, simply return the command unchanged."""
+    return command

--- a/engine/parser.py
+++ b/engine/parser.py
@@ -1,0 +1,5 @@
+"""Simple command parser."""
+
+def parse(command: str) -> str:
+    """Return a normalized command string."""
+    return command.strip().lower()

--- a/engine/world.py
+++ b/engine/world.py
@@ -1,0 +1,61 @@
+"""World representation loaded from data files."""
+
+from pathlib import Path
+from typing import Any, Dict
+
+try:  # pragma: no cover - optional dependency
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - ignore missing library
+    yaml = None  # type: ignore
+
+
+def _simple_yaml_load(fh) -> Dict[str, Any]:
+    """Very small YAML subset loader for environments without PyYAML."""
+    result: Dict[str, Any] = {}
+    stack: list[tuple[Dict[str, Any], int]] = [(result, -1)]
+    for raw in fh:
+        line = raw.rstrip()
+        if not line or line.lstrip().startswith("#"):
+            continue
+        indent = len(line) - len(line.lstrip(" "))
+        key, _, value = line.lstrip().partition(":")
+        key = key.strip()
+        value = value.strip()
+        while indent <= stack[-1][1]:
+            stack.pop()
+        current, _ = stack[-1]
+        if not value:
+            new_dict: Dict[str, Any] = {}
+            current[key] = new_dict
+            stack.append((new_dict, indent))
+        else:
+            if value and value[0] in "'\"" and value[-1] == value[0]:
+                value = value[1:-1]
+            current[key] = value
+    return result
+
+
+class World:
+    def __init__(self, data: Dict[str, Any]):
+        self.rooms = data["rooms"]
+        self.current = data["start"]
+
+    @classmethod
+    def from_file(cls, path: str | Path) -> "World":
+        with open(path, encoding="utf-8") as fh:
+            if yaml is not None:
+                data = yaml.safe_load(fh)
+            else:
+                data = _simple_yaml_load(fh)
+        return cls(data)
+
+    def describe_current(self) -> str:
+        room = self.rooms[self.current]
+        return room["description"]
+
+    def move(self, exit_name: str) -> bool:
+        room = self.rooms[self.current]
+        if exit_name in room.get("exits", {}):
+            self.current = room["exits"][exit_name]
+            return True
+        return False

--- a/game/main.py
+++ b/game/main.py
@@ -1,0 +1,14 @@
+"""Entry point for running the sample adventure."""
+
+from pathlib import Path
+import sys
+
+# Ensure repository root is on the path when executed directly
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
+from engine.game import run
+
+
+if __name__ == "__main__":
+    data_path = Path(__file__).parent.parent / "data" / "world.yaml"
+    run(str(data_path))


### PR DESCRIPTION
## Summary
- load sample world data from YAML instead of JSON
- add simple YAML subset loader to avoid external dependency
- update entry script and docs to use new YAML data file

## Testing
- `python game/main.py`
- `python -m py_compile engine/*.py game/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac8359030483309ef097c9259e2406