### PR TITLE
Fix Poetry package configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,8 @@
 name = "herrschaft-der-asche"
 version = "0.1.0"
 description = "A simple text adventure"
-authors = [""]
+authors = ["Der Mann mit Hut <dermannmithut@metstuebchen.de>"]
+packages = [{ include = "engine" }]
 
 [tool.poetry.dependencies]
 python = ">=3.11,<4.0"


### PR DESCRIPTION
## Summary
- configure Poetry to include the `engine` package
- set project author to Der Mann mit Hut <dermannmithut@metstuebchen.de>

## Testing
- `poetry build -n`
- `poetry run pytest`
- `poetry install` *(fails: All attempts to connect to pypi.org failed)*

------
https://chatgpt.com/codex/tasks/task_e_68acd3946acc8330b55d41e4876bc8ba