### PR TITLE
Delete save file after loading and add look command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,5 +22,6 @@ gestartet.
 Je nach Spracheingabe können Befehle wie `gehe Wald` (Deutsch) oder `go forest` (Englisch) eingegeben werden. Mit `beenden` (Deutsch) bzw. `quit` oder `exit` (Englisch) wird das Spiel beendet.
 
 In der Hütte liegt beispielsweise ein Schlüssel. Gegenstände können mit `nimm`/`take` aufgenommen, mit `lege`/`drop` wieder abgelegt und mit `inventar`/`inventory` angezeigt werden.
+Mit `umsehen`/`look` lässt sich die Beschreibung des aktuellen Raums erneut ausgeben. Mit `umsehen Schlüssel`/`look key` erhält man die Beschreibung eines Gegenstands.
 
 Die Welt- und Übersetzungsdaten liegen in den Unterverzeichnissen `data/de/` bzw. `data/en/`.

--- a/data/de/commands.yaml
+++ b/data/de/commands.yaml
@@ -5,4 +5,7 @@ take: "nimm"
 drop: "lege"
 drop_suffix: "ab"
 inventory: "inventar"
+look:
+  - "umschau"
+  - "umsehen"
 

--- a/data/de/world.yaml
+++ b/data/de/world.yaml
@@ -2,6 +2,7 @@ items:
   key:
     names:
       - Schlüssel
+    description: "Ein kleiner Messingschlüssel."
 rooms:
   hut:
     description: "Du befindest dich in einer kleinen Hütte. Eine Tür führt nach draußen in den Wald."

--- a/data/en/commands.yaml
+++ b/data/en/commands.yaml
@@ -6,4 +6,7 @@ take: "take"
 drop: "drop"
 drop_suffix: ""
 inventory: "inventory"
+look:
+  - "look"
+  - "look around"
 

--- a/data/en/world.yaml
+++ b/data/en/world.yaml
@@ -2,6 +2,7 @@ items:
   key:
     names:
       - key
+    description: "A small brass key."
 rooms:
   hut:
     description: "You are in a small hut. A door leads out to the forest."

--- a/data/generic/commands.yaml
+++ b/data/generic/commands.yaml
@@ -3,3 +3,4 @@
 - take
 - drop
 - inventory
+- look

--- a/engine/game.py
+++ b/engine/game.py
@@ -12,6 +12,7 @@ class Game:
         self.world = world.World.from_file(world_data_path)
         if self.save_path.exists():
             self.world.load_state(self.save_path)
+            self.save_path.unlink()
         self.messages = i18n.load_messages(language)
         self.commands = i18n.load_commands(language)
         command_keys = i18n.load_command_keys()
@@ -67,6 +68,16 @@ class Game:
             io.output(self.messages["dropped"].format(item=item))
         else:
             io.output(self.messages["not_carrying"])
+
+    def cmd_look(self, arg: str) -> None:
+        if arg:
+            desc = self.world.describe_item(arg)
+            if desc:
+                io.output(desc)
+            else:
+                io.output(self.messages["item_not_present"])
+        else:
+            io.output(self.world.describe_current(self.messages))
 
     def cmd_go(self, arg: str) -> None:
         if not arg:

--- a/engine/world.py
+++ b/engine/world.py
@@ -57,6 +57,21 @@ class World:
                 desc += " You see here: " + ", ".join(item_names)
         return desc
 
+    def describe_item(self, item_name: str) -> str | None:
+        item_name_cf = item_name.casefold()
+        room = self.rooms[self.current]
+        for item_id in room.get("items", []):
+            item = self.items.get(item_id, {})
+            names = item.get("names", [])
+            if any(name.casefold() == item_name_cf for name in names):
+                return item.get("description")
+        for item_id in self.inventory:
+            item = self.items.get(item_id, {})
+            names = item.get("names", [])
+            if any(name.casefold() == item_name_cf for name in names):
+                return item.get("description")
+        return None
+
     def move(self, exit_name: str) -> bool:
         room = self.rooms[self.current]
         exits = room.get("exits", {})

--- a/tests/test_look_item.py
+++ b/tests/test_look_item.py
@@ -1,0 +1,24 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from engine import game, io
+
+
+def test_look_item_describes(monkeypatch):
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    g = game.Game("data/en/world.yaml", "en")
+    g.cmd_look("key")
+    assert outputs[-1] == "A small brass key."
+
+
+def test_look_item_not_present(monkeypatch):
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    g = game.Game("data/en/world.yaml", "en")
+    g.world.move("forest")
+    g.cmd_look("key")
+    assert outputs[-1] == g.messages["item_not_present"]
+


### PR DESCRIPTION
## Summary
- remove save file right after loading the saved state
- add a look/umsehen command to reprint current room description
- allow `look <item>` to print an item's description

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ad704545f883308762b991639f130b