### PR TITLE
Extract language-neutral world configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,6 @@ Je nach Spracheingabe können Befehle wie `gehe Wald` (Deutsch) oder `go forest`
 In der Hütte liegt beispielsweise ein Schlüssel. Gegenstände können mit `nimm`/`take` aufgenommen, mit `lege`/`drop` wieder abgelegt und mit `inventar`/`inventory` angezeigt werden.
 Mit `umsehen`/`look` lässt sich die Beschreibung des aktuellen Raums erneut ausgeben. Mit `umsehen Schlüssel`/`look key` erhält man die Beschreibung eines Gegenstands. Mit `hilfe`/`help` werden alle verfügbaren Befehle angezeigt. Mit `sprache <id>`/`language <id>` kann die Sprache gewechselt werden.
 
-Die Welt- und Übersetzungsdaten liegen in den Unterverzeichnissen `data/de/` bzw. `data/en/`.
+Die sprachunabhängige Weltkonfiguration befindet sich in `data/generic/world.yaml`.
+Sprachspezifische Texte und Bezeichnungen liegen in den Unterverzeichnissen
+`data/de/` bzw. `data/en/`.

--- a/data/de/world.yaml
+++ b/data/de/world.yaml
@@ -5,15 +5,10 @@ items:
     description: "Ein kleiner Messingschlüssel."
 rooms:
   hut:
+    names:
+      - Hütte
     description: "Du befindest dich in einer kleinen Hütte. Eine Tür führt nach draußen in den Wald."
-    items:
-      - key
-    exits:
-      forest:
-        - Wald
   forest:
+    names:
+      - Wald
     description: "Du stehst auf einer Lichtung im Wald. Zurück geht es in die Hütte."
-    exits:
-      hut:
-        - Hütte
-start: hut

--- a/data/en/world.yaml
+++ b/data/en/world.yaml
@@ -5,15 +5,10 @@ items:
     description: "A small brass key."
 rooms:
   hut:
+    names:
+      - hut
     description: "You are in a small hut. A door leads out to the forest."
-    items:
-      - key
-    exits:
-      forest:
-        - forest
   forest:
+    names:
+      - forest
     description: "You stand in a clearing in the forest. The hut is back the way you came."
-    exits:
-      hut:
-        - hut
-start: hut

--- a/data/generic/world.yaml
+++ b/data/generic/world.yaml
@@ -1,0 +1,12 @@
+items:
+  key: {}
+rooms:
+  hut:
+    items:
+      - key
+    exits:
+      - forest
+  forest:
+    exits:
+      - hut
+start: hut

--- a/engine/game.py
+++ b/engine/game.py
@@ -12,7 +12,8 @@ class Game:
         data_path = Path(world_data_path)
         self.data_dir = data_path.parent.parent
         self.save_path = self.data_dir / "save.yaml"
-        self.world = world.World.from_file(world_data_path)
+        generic_path = self.data_dir / "generic" / "world.yaml"
+        self.world = world.World.from_files(generic_path, world_data_path)
         self.language = language
         if self.save_path.exists():
             with open(self.save_path, encoding="utf-8") as fh:
@@ -122,7 +123,8 @@ class Game:
             messages = i18n.load_messages(language)
             commands = i18n.load_commands(language)
             world_path = self.data_dir / language / "world.yaml"
-            new_world = world.World.from_file(world_path)
+            generic_path = self.data_dir / "generic" / "world.yaml"
+            new_world = world.World.from_files(generic_path, world_path)
         except FileNotFoundError:
             io.output(self.messages.get("language_unknown", "Unknown language"))
             return


### PR DESCRIPTION
## Summary
- Store world structure (rooms, exits, items, start room) in `data/generic/world.yaml`
- Load world data by merging generic configuration with language-specific texts, deriving exit names from target room names
- Update game engine to use the new loader and adjust documentation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ad8812996c8330b92a1597ce374fda