### PR TITLE
Ensure savegame is written on unexpected termination

### DIFF
--- a/engine/game.py
+++ b/engine/game.py
@@ -37,15 +37,20 @@ class Game:
 
     def run(self) -> None:
         io.output(self.world.describe_current(self.messages))
-        while self.running:
-            raw = io.get_input()
-            raw = llm.interpret(raw)
-            raw = parser.parse(raw)
-            cmd_word, *rest = raw.split(" ", 1)
-            cmd_key = self.reverse_cmds.get(cmd_word)
-            arg = rest[0] if rest else ""
-            handler = getattr(self, f"cmd_{cmd_key}", self.cmd_unknown)
-            handler(arg)
+        try:
+            while self.running:
+                raw = io.get_input()
+                raw = llm.interpret(raw)
+                raw = parser.parse(raw)
+                cmd_word, *rest = raw.split(" ", 1)
+                cmd_key = self.reverse_cmds.get(cmd_word)
+                arg = rest[0] if rest else ""
+                handler = getattr(self, f"cmd_{cmd_key}", self.cmd_unknown)
+                handler(arg)
+        except (EOFError, KeyboardInterrupt):
+            io.output(self.messages["farewell"])
+        finally:
+            self._save_state()
 
     def _save_state(self) -> None:
         data = self.world.to_state()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,16 +10,49 @@ if str(ROOT_DIR) not in sys.path:
 
 
 @pytest.fixture
-def make_data_dir(tmp_path):
-    def _make_data_dir(*, generic, **languages):
-        (tmp_path / "generic").mkdir()
-        with open(tmp_path / "generic" / "world.yaml", "w", encoding="utf-8") as fh:
-            yaml.safe_dump(generic, fh)
-        for lang, data in languages.items():
-            lang_dir = tmp_path / lang
-            lang_dir.mkdir()
-            with open(lang_dir / "world.yaml", "w", encoding="utf-8") as fh:
-                yaml.safe_dump(data, fh)
-        return tmp_path
+def data_dir(tmp_path):
+    generic = {
+        "items": {"sword": {}, "gem": {}},
+        "rooms": {
+            "start": {"exits": ["room2", "room3"]},
+            "room2": {"items": ["gem"], "exits": ["start", "room3"]},
+            "room3": {"items": ["sword"], "exits": ["start", "room2"]},
+        },
+        "start": "start",
+    }
 
-    return _make_data_dir
+    en = {
+        "items": {
+            "sword": {"names": ["Sword"], "description": "A sharp blade."},
+            "gem": {"names": ["Gem"], "description": "A shiny gem."},
+        },
+        "rooms": {
+            "start": {"names": ["Room 1"], "description": "Room 1."},
+            "room2": {"names": ["Room 2"], "description": "Room 2."},
+            "room3": {"names": ["Room 3"], "description": "Room 3."},
+        },
+    }
+
+    de = {
+        "items": {
+            "sword": {"names": ["Schwert"], "description": "Eine scharfe Klinge."},
+            "gem": {"names": ["Juwel"], "description": "Ein glänzendes Juwel."},
+        },
+        "rooms": {
+            "start": {"names": ["Raum 1"], "description": "Raum 1."},
+            "room2": {"names": ["Raum 2"], "description": "Raum 2."},
+            "room3": {"names": ["Raum 3"], "description": "Raum 3."},
+        },
+    }
+
+    (tmp_path / "generic").mkdir()
+    with open(tmp_path / "generic" / "world.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(generic, fh)
+
+    for lang, data in {"en": en, "de": de}.items():
+        lang_dir = tmp_path / lang
+        lang_dir.mkdir()
+        with open(lang_dir / "world.yaml", "w", encoding="utf-8") as fh:
+            yaml.safe_dump(data, fh)
+
+    return tmp_path

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,25 @@
 import sys
 from pathlib import Path
 
+import pytest
+import yaml
+
 ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.append(str(ROOT_DIR))
+
+
+@pytest.fixture
+def make_data_dir(tmp_path):
+    def _make_data_dir(*, generic, **languages):
+        (tmp_path / "generic").mkdir()
+        with open(tmp_path / "generic" / "world.yaml", "w", encoding="utf-8") as fh:
+            yaml.safe_dump(generic, fh)
+        for lang, data in languages.items():
+            lang_dir = tmp_path / lang
+            lang_dir.mkdir()
+            with open(lang_dir / "world.yaml", "w", encoding="utf-8") as fh:
+                yaml.safe_dump(data, fh)
+        return tmp_path
+
+    return _make_data_dir

--- a/tests/test_auto_save.py
+++ b/tests/test_auto_save.py
@@ -3,20 +3,7 @@ import pytest
 from engine import game, io, parser
 
 
-GENERIC = {
-    "items": {"sword": {}},
-    "rooms": {"start": {"items": ["sword"], "exits": []}},
-    "start": "start",
-}
-
-EN = {
-    "items": {"sword": {"names": ["Sword"], "description": "A sharp blade."}},
-    "rooms": {"start": {"names": ["Start"], "description": "Start room."}},
-}
-
-
-def test_save_on_eoferror(make_data_dir, monkeypatch):
-    data_dir = make_data_dir(generic=GENERIC, en=EN)
+def test_save_on_eoferror(data_dir, monkeypatch):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
 
     def fake_input(prompt: str = "> ") -> str:  # noqa: ARG001
@@ -31,8 +18,7 @@ def test_save_on_eoferror(make_data_dir, monkeypatch):
     assert data["current"] == "start"
 
 
-def test_save_on_exception(make_data_dir, monkeypatch):
-    data_dir = make_data_dir(generic=GENERIC, en=EN)
+def test_save_on_exception(data_dir, monkeypatch):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     monkeypatch.setattr(io, "get_input", lambda prompt="> ": "look")
 

--- a/tests/test_auto_save.py
+++ b/tests/test_auto_save.py
@@ -1,0 +1,54 @@
+import yaml
+import pytest
+from pathlib import Path
+from engine import game, io, parser
+
+
+def make_data_dir(tmp_path: Path) -> Path:
+    (tmp_path / "generic").mkdir()
+    (tmp_path / "en").mkdir()
+    generic = {
+        "items": {"sword": {}},
+        "rooms": {"start": {"items": ["sword"], "exits": []}},
+        "start": "start",
+    }
+    en = {
+        "items": {"sword": {"names": ["Sword"], "description": "A sharp blade."}},
+        "rooms": {"start": {"names": ["Start"], "description": "Start room."}},
+    }
+    with open(tmp_path / "generic" / "world.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(generic, fh)
+    with open(tmp_path / "en" / "world.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(en, fh)
+    return tmp_path
+
+
+def test_save_on_eoferror(tmp_path, monkeypatch):
+    data_dir = make_data_dir(tmp_path)
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+
+    def fake_input(prompt: str = "> ") -> str:  # noqa: ARG001
+        raise EOFError
+
+    monkeypatch.setattr(io, "get_input", fake_input)
+    g.run()
+    save_path = data_dir / "save.yaml"
+    assert save_path.exists()
+    with open(save_path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    assert data["current"] == "start"
+
+
+def test_save_on_exception(tmp_path, monkeypatch):
+    data_dir = make_data_dir(tmp_path)
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    monkeypatch.setattr(io, "get_input", lambda prompt="> ": "look")
+
+    def boom(cmd: str) -> str:  # noqa: ARG001
+        raise ValueError("boom")
+
+    monkeypatch.setattr(parser, "parse", boom)
+    with pytest.raises(ValueError):
+        g.run()
+    save_path = data_dir / "save.yaml"
+    assert save_path.exists()

--- a/tests/test_auto_save.py
+++ b/tests/test_auto_save.py
@@ -1,30 +1,22 @@
 import yaml
 import pytest
-from pathlib import Path
 from engine import game, io, parser
 
 
-def make_data_dir(tmp_path: Path) -> Path:
-    (tmp_path / "generic").mkdir()
-    (tmp_path / "en").mkdir()
-    generic = {
-        "items": {"sword": {}},
-        "rooms": {"start": {"items": ["sword"], "exits": []}},
-        "start": "start",
-    }
-    en = {
-        "items": {"sword": {"names": ["Sword"], "description": "A sharp blade."}},
-        "rooms": {"start": {"names": ["Start"], "description": "Start room."}},
-    }
-    with open(tmp_path / "generic" / "world.yaml", "w", encoding="utf-8") as fh:
-        yaml.safe_dump(generic, fh)
-    with open(tmp_path / "en" / "world.yaml", "w", encoding="utf-8") as fh:
-        yaml.safe_dump(en, fh)
-    return tmp_path
+GENERIC = {
+    "items": {"sword": {}},
+    "rooms": {"start": {"items": ["sword"], "exits": []}},
+    "start": "start",
+}
+
+EN = {
+    "items": {"sword": {"names": ["Sword"], "description": "A sharp blade."}},
+    "rooms": {"start": {"names": ["Start"], "description": "Start room."}},
+}
 
 
-def test_save_on_eoferror(tmp_path, monkeypatch):
-    data_dir = make_data_dir(tmp_path)
+def test_save_on_eoferror(make_data_dir, monkeypatch):
+    data_dir = make_data_dir(generic=GENERIC, en=EN)
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
 
     def fake_input(prompt: str = "> ") -> str:  # noqa: ARG001
@@ -39,8 +31,8 @@ def test_save_on_eoferror(tmp_path, monkeypatch):
     assert data["current"] == "start"
 
 
-def test_save_on_exception(tmp_path, monkeypatch):
-    data_dir = make_data_dir(tmp_path)
+def test_save_on_exception(make_data_dir, monkeypatch):
+    data_dir = make_data_dir(generic=GENERIC, en=EN)
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     monkeypatch.setattr(io, "get_input", lambda prompt="> ": "look")
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,23 +1,15 @@
-import yaml
 from engine import game, io
 
 
-def make_game(tmp_path):
-    (tmp_path / "generic").mkdir()
-    (tmp_path / "en").mkdir()
-    generic = {"rooms": {"start": {"exits": []}}, "start": "start"}
-    en = {"rooms": {"start": {"names": ["Start"], "description": "Start room."}}}
-    with open(tmp_path / "generic" / "world.yaml", "w", encoding="utf-8") as fh:
-        yaml.safe_dump(generic, fh)
-    with open(tmp_path / "en" / "world.yaml", "w", encoding="utf-8") as fh:
-        yaml.safe_dump(en, fh)
-    return game.Game(str(tmp_path / "en" / "world.yaml"), "en")
+GENERIC = {"rooms": {"start": {"exits": []}}, "start": "start"}
+EN = {"rooms": {"start": {"names": ["Start"], "description": "Start room."}}}
 
 
-def test_help_lists_commands(tmp_path, monkeypatch):
+def test_help_lists_commands(make_data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = make_game(tmp_path)
+    data_dir = make_data_dir(generic=GENERIC, en=EN)
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     g.cmd_help("")
     names = []
     for key in g.command_keys:

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,14 +1,9 @@
 from engine import game, io
 
 
-GENERIC = {"rooms": {"start": {"exits": []}}, "start": "start"}
-EN = {"rooms": {"start": {"names": ["Start"], "description": "Start room."}}}
-
-
-def test_help_lists_commands(make_data_dir, monkeypatch):
+def test_help_lists_commands(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    data_dir = make_data_dir(generic=GENERIC, en=EN)
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     g.cmd_help("")
     names = []

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -1,25 +1,7 @@
 from engine import game, io
 
 
-GENERIC = {
-    "items": {"sword": {}},
-    "rooms": {"start": {"items": ["sword"], "exits": []}},
-    "start": "start",
-}
-
-EN = {
-    "items": {"sword": {"names": ["Sword"], "description": "A sharp blade."}},
-    "rooms": {"start": {"names": ["Start"], "description": "Start room."}},
-}
-
-DE = {
-    "items": {"sword": {"names": ["Schwert"], "description": "Eine scharfe Klinge."}},
-    "rooms": {"start": {"names": ["Start"], "description": "Startraum."}},
-}
-
-
-def test_language_switch(make_data_dir, monkeypatch):
-    data_dir = make_data_dir(generic=GENERIC, en=EN, de=DE)
+def test_language_switch(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
@@ -33,8 +15,7 @@ def test_language_switch(make_data_dir, monkeypatch):
     assert g.world.items["sword"]["names"][0] == "Schwert"
 
 
-def test_language_persistence(make_data_dir, monkeypatch):
-    data_dir = make_data_dir(generic=GENERIC, en=EN, de=DE)
+def test_language_persistence(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
@@ -46,8 +27,7 @@ def test_language_persistence(make_data_dir, monkeypatch):
     assert g2.reverse_cmds["language"] == "language"
 
 
-def test_language_command_base_word(make_data_dir, monkeypatch):
-    data_dir = make_data_dir(generic=GENERIC, en=EN, de=DE)
+def test_language_command_base_word(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "de" / "world.yaml"), "de")

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -1,35 +1,25 @@
-import yaml
 from engine import game, io
 
 
-def make_data_dir(tmp_path):
-    (tmp_path / "generic").mkdir()
-    (tmp_path / "en").mkdir()
-    (tmp_path / "de").mkdir()
-    generic = {
-        "items": {"sword": {}},
-        "rooms": {"start": {"items": ["sword"], "exits": []}},
-        "start": "start",
-    }
-    en = {
-        "items": {"sword": {"names": ["Sword"], "description": "A sharp blade."}},
-        "rooms": {"start": {"names": ["Start"], "description": "Start room."}},
-    }
-    de = {
-        "items": {"sword": {"names": ["Schwert"], "description": "Eine scharfe Klinge."}},
-        "rooms": {"start": {"names": ["Start"], "description": "Startraum."}},
-    }
-    with open(tmp_path / "generic" / "world.yaml", "w", encoding="utf-8") as fh:
-        yaml.safe_dump(generic, fh)
-    with open(tmp_path / "en" / "world.yaml", "w", encoding="utf-8") as fh:
-        yaml.safe_dump(en, fh)
-    with open(tmp_path / "de" / "world.yaml", "w", encoding="utf-8") as fh:
-        yaml.safe_dump(de, fh)
-    return tmp_path
+GENERIC = {
+    "items": {"sword": {}},
+    "rooms": {"start": {"items": ["sword"], "exits": []}},
+    "start": "start",
+}
+
+EN = {
+    "items": {"sword": {"names": ["Sword"], "description": "A sharp blade."}},
+    "rooms": {"start": {"names": ["Start"], "description": "Start room."}},
+}
+
+DE = {
+    "items": {"sword": {"names": ["Schwert"], "description": "Eine scharfe Klinge."}},
+    "rooms": {"start": {"names": ["Start"], "description": "Startraum."}},
+}
 
 
-def test_language_switch(tmp_path, monkeypatch):
-    data_dir = make_data_dir(tmp_path)
+def test_language_switch(make_data_dir, monkeypatch):
+    data_dir = make_data_dir(generic=GENERIC, en=EN, de=DE)
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
@@ -43,8 +33,8 @@ def test_language_switch(tmp_path, monkeypatch):
     assert g.world.items["sword"]["names"][0] == "Schwert"
 
 
-def test_language_persistence(tmp_path, monkeypatch):
-    data_dir = make_data_dir(tmp_path)
+def test_language_persistence(make_data_dir, monkeypatch):
+    data_dir = make_data_dir(generic=GENERIC, en=EN, de=DE)
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
@@ -56,8 +46,8 @@ def test_language_persistence(tmp_path, monkeypatch):
     assert g2.reverse_cmds["language"] == "language"
 
 
-def test_language_command_base_word(tmp_path, monkeypatch):
-    data_dir = make_data_dir(tmp_path)
+def test_language_command_base_word(make_data_dir, monkeypatch):
+    data_dir = make_data_dir(generic=GENERIC, en=EN, de=DE)
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "de" / "world.yaml"), "de")

--- a/tests/test_look_exits.py
+++ b/tests/test_look_exits.py
@@ -1,39 +1,17 @@
 from engine import game, io
 
 
-GENERIC = {
-    "items": {"gem": {}},
-    "rooms": {
-        "room1": {"exits": ["room2", "room3"]},
-        "room2": {"items": ["gem"], "exits": ["room1", "room3"]},
-        "room3": {"exits": ["room1", "room2"]},
-    },
-    "start": "room1",
-}
-
-EN = {
-    "items": {"gem": {"names": ["Gem"], "description": "A shiny gem."}},
-    "rooms": {
-        "room1": {"names": ["Room 1"], "description": "Room 1."},
-        "room2": {"names": ["Room 2"], "description": "Room 2."},
-        "room3": {"names": ["Room 3"], "description": "Room 3."},
-    },
-}
-
-
-def test_room_description_lists_exits(make_data_dir, monkeypatch):
+def test_room_description_lists_exits(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    data_dir = make_data_dir(generic=GENERIC, en=EN)
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     g.cmd_look("")
     assert outputs[-1] == "Room 1. Exits: Room 2, Room 3."
 
 
-def test_room_description_lists_items_and_exits(make_data_dir, monkeypatch):
+def test_room_description_lists_items_and_exits(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    data_dir = make_data_dir(generic=GENERIC, en=EN)
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
     g.cmd_look("")

--- a/tests/test_look_exits.py
+++ b/tests/test_look_exits.py
@@ -1,46 +1,40 @@
-import yaml
 from engine import game, io
 
 
-def make_game(tmp_path):
-    (tmp_path / "generic").mkdir()
-    (tmp_path / "en").mkdir()
-    generic = {
-        "items": {"gem": {}},
-        "rooms": {
-            "room1": {"exits": ["room2", "room3"]},
-            "room2": {"items": ["gem"], "exits": ["room1", "room3"]},
-            "room3": {"exits": ["room1", "room2"]},
-        },
-        "start": "room1",
-    }
-    en = {
-        "items": {"gem": {"names": ["Gem"], "description": "A shiny gem."}},
-        "rooms": {
-            "room1": {"names": ["Room 1"], "description": "Room 1."},
-            "room2": {"names": ["Room 2"], "description": "Room 2."},
-            "room3": {"names": ["Room 3"], "description": "Room 3."},
-        },
-    }
-    with open(tmp_path / "generic" / "world.yaml", "w", encoding="utf-8") as fh:
-        yaml.safe_dump(generic, fh)
-    with open(tmp_path / "en" / "world.yaml", "w", encoding="utf-8") as fh:
-        yaml.safe_dump(en, fh)
-    return game.Game(str(tmp_path / "en" / "world.yaml"), "en")
+GENERIC = {
+    "items": {"gem": {}},
+    "rooms": {
+        "room1": {"exits": ["room2", "room3"]},
+        "room2": {"items": ["gem"], "exits": ["room1", "room3"]},
+        "room3": {"exits": ["room1", "room2"]},
+    },
+    "start": "room1",
+}
+
+EN = {
+    "items": {"gem": {"names": ["Gem"], "description": "A shiny gem."}},
+    "rooms": {
+        "room1": {"names": ["Room 1"], "description": "Room 1."},
+        "room2": {"names": ["Room 2"], "description": "Room 2."},
+        "room3": {"names": ["Room 3"], "description": "Room 3."},
+    },
+}
 
 
-def test_room_description_lists_exits(tmp_path, monkeypatch):
+def test_room_description_lists_exits(make_data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = make_game(tmp_path)
+    data_dir = make_data_dir(generic=GENERIC, en=EN)
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     g.cmd_look("")
     assert outputs[-1] == "Room 1. Exits: Room 2, Room 3."
 
 
-def test_room_description_lists_items_and_exits(tmp_path, monkeypatch):
+def test_room_description_lists_items_and_exits(make_data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = make_game(tmp_path)
+    data_dir = make_data_dir(generic=GENERIC, en=EN)
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
     g.cmd_look("")
     assert outputs[-1] == "Room 2. You see here: Gem. Exits: Room 1, Room 3."

--- a/tests/test_look_item.py
+++ b/tests/test_look_item.py
@@ -1,38 +1,18 @@
 from engine import game, io
 
 
-GENERIC = {
-    "items": {"gem": {}},
-    "rooms": {
-        "room1": {"exits": ["room2"]},
-        "room2": {"items": ["gem"], "exits": ["room1"]},
-    },
-    "start": "room1",
-}
-
-EN = {
-    "items": {"gem": {"names": ["Gem"], "description": "A shiny gem."}},
-    "rooms": {
-        "room1": {"names": ["Room 1"], "description": "Room 1."},
-        "room2": {"names": ["Room 2"], "description": "Room 2."},
-    },
-}
-
-
-def test_look_item_describes(make_data_dir, monkeypatch):
+def test_look_item_describes(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    data_dir = make_data_dir(generic=GENERIC, en=EN)
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
     g.cmd_look("gem")
     assert outputs[-1] == "A shiny gem."
 
 
-def test_look_item_not_present(make_data_dir, monkeypatch):
+def test_look_item_not_present(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    data_dir = make_data_dir(generic=GENERIC, en=EN)
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
     g.cmd_look("sword")

--- a/tests/test_look_item.py
+++ b/tests/test_look_item.py
@@ -1,45 +1,39 @@
-import yaml
 from engine import game, io
 
 
-def make_game(tmp_path):
-    (tmp_path / "generic").mkdir()
-    (tmp_path / "en").mkdir()
-    generic = {
-        "items": {"gem": {}},
-        "rooms": {
-            "room1": {"exits": ["room2"]},
-            "room2": {"items": ["gem"], "exits": ["room1"]},
-        },
-        "start": "room1",
-    }
-    en = {
-        "items": {"gem": {"names": ["Gem"], "description": "A shiny gem."}},
-        "rooms": {
-            "room1": {"names": ["Room 1"], "description": "Room 1."},
-            "room2": {"names": ["Room 2"], "description": "Room 2."},
-        },
-    }
-    with open(tmp_path / "generic" / "world.yaml", "w", encoding="utf-8") as fh:
-        yaml.safe_dump(generic, fh)
-    with open(tmp_path / "en" / "world.yaml", "w", encoding="utf-8") as fh:
-        yaml.safe_dump(en, fh)
-    return game.Game(str(tmp_path / "en" / "world.yaml"), "en")
+GENERIC = {
+    "items": {"gem": {}},
+    "rooms": {
+        "room1": {"exits": ["room2"]},
+        "room2": {"items": ["gem"], "exits": ["room1"]},
+    },
+    "start": "room1",
+}
+
+EN = {
+    "items": {"gem": {"names": ["Gem"], "description": "A shiny gem."}},
+    "rooms": {
+        "room1": {"names": ["Room 1"], "description": "Room 1."},
+        "room2": {"names": ["Room 2"], "description": "Room 2."},
+    },
+}
 
 
-def test_look_item_describes(tmp_path, monkeypatch):
+def test_look_item_describes(make_data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = make_game(tmp_path)
+    data_dir = make_data_dir(generic=GENERIC, en=EN)
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
     g.cmd_look("gem")
     assert outputs[-1] == "A shiny gem."
 
 
-def test_look_item_not_present(tmp_path, monkeypatch):
+def test_look_item_not_present(make_data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = make_game(tmp_path)
+    data_dir = make_data_dir(generic=GENERIC, en=EN)
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
     g.cmd_look("sword")
     assert outputs[-1] == g.messages["item_not_present"]


### PR DESCRIPTION
## Summary
- Save game state when the game loop terminates, including on user abort and errors
- Add regression tests to ensure save files are created on EOFError or other exceptions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68add7570af0833085eddf3d9adc4e91