### PR TITLE
Add item state system with Aschenkrone states

### DIFF
--- a/data/de/world.yaml
+++ b/data/de/world.yaml
@@ -4,7 +4,11 @@ items:
       - Aschenkrone
       - Krone
       - Krone der Asche
-    description: "Eine zerbrochene Krone, bedeckt von grauer Asche. Sie scheint von unheimlicher Hitze erfüllt."
+    states:
+      broken:
+        description: "Eine zerbrochene Krone, bedeckt von grauer Asche. Sie scheint von unheimlicher Hitze erfüllt."
+      repaired:
+        description: "Eine glänzende, reparierte Krone, frei von jeder Asche. Eine sanfte Wärme geht von ihr aus."
   flame_blade:
     names:
       - Flammenklinge

--- a/data/en/world.yaml
+++ b/data/en/world.yaml
@@ -4,7 +4,11 @@ items:
       - Ashen Crown
       - Crown
       - Crown of Ash
-    description: "A broken crown, covered in gray ash. It seems to radiate an uncanny heat."
+    states:
+      broken:
+        description: "A broken crown, covered in gray ash. It seems to radiate an uncanny heat."
+      repaired:
+        description: "A gleaming, fully repaired crown, free of ash. A gentle warmth emanates from it."
   flame_blade:
     names:
       - Flame Blade

--- a/data/generic/world.yaml
+++ b/data/generic/world.yaml
@@ -1,5 +1,9 @@
 items:
-  ashen_crown: {}
+  ashen_crown:
+    state: broken
+    states:
+      broken: {}
+      repaired: {}
   flame_blade: {}
 
 rooms:

--- a/engine/world.py
+++ b/engine/world.py
@@ -12,11 +12,18 @@ class World:
         self.items = data.get("items", {})
         self.current = data["start"]
         self.inventory: list[str] = data.get("inventory", [])
+        # Track states for items that define them.
+        self.item_states: Dict[str, str] = {
+            item_id: item_data.get("state")
+            for item_id, item_data in self.items.items()
+            if item_data.get("state") is not None
+        }
         # Remember the initial state so that we can later compute differences.
         self._base_rooms: Dict[str, list[str]] = {
             room_id: list(room.get("items", [])) for room_id, room in self.rooms.items()
         }
         self._base_inventory: list[str] = list(self.inventory)
+        self._base_item_states: Dict[str, str] = dict(self.item_states)
 
     @classmethod
     def from_file(cls, path: str | Path) -> "World":
@@ -32,7 +39,15 @@ class World:
             lang = yaml.safe_load(fh)
         items: Dict[str, Any] = base.get("items", {})
         for item_id, item_data in lang.get("items", {}).items():
-            items.setdefault(item_id, {}).update(item_data)
+            item_cfg = items.setdefault(item_id, {})
+            lang_states = item_data.get("states")
+            if lang_states:
+                base_states = item_cfg.setdefault("states", {})
+                for state_id, state_cfg in lang_states.items():
+                    base_states.setdefault(state_id, {}).update(state_cfg)
+            for key, value in item_data.items():
+                if key != "states":
+                    item_cfg[key] = value
         rooms: Dict[str, Any] = {}
         lang_rooms = lang.get("rooms", {})
         for room_id, cfg_room in base.get("rooms", {}).items():
@@ -69,6 +84,12 @@ class World:
                 rooms_diff[room_id] = items
         if rooms_diff:
             state["rooms"] = rooms_diff
+        states_diff: Dict[str, str] = {}
+        for item_id, cur_state in self.item_states.items():
+            if self._base_item_states.get(item_id) != cur_state:
+                states_diff[item_id] = cur_state
+        if states_diff:
+            state["item_states"] = states_diff
         return state
 
     def save(self, path: str | Path) -> None:
@@ -90,6 +111,11 @@ class World:
                 room["items"] = items
             else:
                 room.pop("items", None)
+        item_states = data.get("item_states", {})
+        for item_id, state in item_states.items():
+            if item_id in self.item_states:
+                self.item_states[item_id] = state
+                self.items[item_id]["state"] = state
 
     def describe_current(self, messages: Dict[str, str] | None = None) -> str:
         room = self.rooms[self.current]
@@ -122,11 +148,21 @@ class World:
             item = self.items.get(item_id, {})
             names = item.get("names", [])
             if any(name.casefold() == item_name_cf for name in names):
+                state = self.item_states.get(item_id)
+                if state:
+                    desc = item.get("states", {}).get(state, {}).get("description")
+                    if desc is not None:
+                        return desc
                 return item.get("description")
         for item_id in self.inventory:
             item = self.items.get(item_id, {})
             names = item.get("names", [])
             if any(name.casefold() == item_name_cf for name in names):
+                state = self.item_states.get(item_id)
+                if state:
+                    desc = item.get("states", {}).get(state, {}).get("description")
+                    if desc is not None:
+                        return desc
                 return item.get("description")
         return None
 
@@ -166,6 +202,20 @@ class World:
                 room.setdefault("items", []).append(item_id)
                 return True
         return False
+
+    def set_item_state(self, item_id: str, state: str) -> bool:
+        """Set the state for an item if the state exists.
+
+        Returns True if the state was changed, False otherwise."""
+        item = self.items.get(item_id)
+        if not item:
+            return False
+        states = item.get("states")
+        if not states or state not in states:
+            return False
+        self.item_states[item_id] = state
+        item["state"] = state
+        return True
 
     def describe_inventory(self, messages: Dict[str, str]) -> str:
         if not self.inventory:

--- a/tests/test_item_states.py
+++ b/tests/test_item_states.py
@@ -1,0 +1,65 @@
+from engine.world import World
+import yaml
+import pytest
+
+
+def make_world() -> World:
+    data = {
+        "items": {
+            "crown": {
+                "names": ["crown"],
+                "state": "broken",
+                "states": {
+                    "broken": {"description": "A broken crown."},
+                    "repaired": {"description": "A repaired crown."},
+                },
+            }
+        },
+        "rooms": {
+            "room1": {"description": "Room 1.", "items": ["crown"], "exits": {}}
+        },
+        "start": "room1",
+    }
+    return World(data)
+
+
+def test_describe_item_state_changes():
+    w = make_world()
+    assert w.describe_item("crown") == "A broken crown."
+    assert w.set_item_state("crown", "repaired")
+    assert w.describe_item("crown") == "A repaired crown."
+
+
+def test_item_state_saved_and_loaded(tmp_path):
+    w = make_world()
+    assert w.set_item_state("crown", "repaired")
+    save_path = tmp_path / "save.yaml"
+    w.save(save_path)
+
+    new = make_world()
+    new.load_state(save_path)
+    assert new.item_states["crown"] == "repaired"
+    assert new.describe_item("crown") == "A repaired crown."
+    with open(save_path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    assert data["item_states"] == {"crown": "repaired"}
+
+
+@pytest.mark.parametrize(
+    "language,item_name,broken_phrase,repaired_phrase,exit_name",
+    [
+        ("en", "Ashen Crown", "broken crown", "repaired crown", "Black Tower"),
+        ("de", "Aschenkrone", "zerbrochene krone", "reparierte krone", "Schwarzer Turm"),
+    ],
+)
+def test_states_from_files(language, item_name, broken_phrase, repaired_phrase, exit_name):
+    w = World.from_files("data/generic/world.yaml", f"data/{language}/world.yaml")
+    assert w.item_states["ashen_crown"] == "broken"
+    assert w.move(exit_name)
+    desc = w.describe_item(item_name)
+    assert desc is not None
+    assert broken_phrase in desc.lower()
+    assert w.set_item_state("ashen_crown", "repaired")
+    desc = w.describe_item(item_name)
+    assert desc is not None
+    assert repaired_phrase in desc.lower()


### PR DESCRIPTION
## Summary
- allow items to have named states with independent descriptions
- describe, save and restore item states
- add broken and repaired states for Aschenkrone
- cover item state behaviour with tests
- declare item states in generic world data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68add7c7133c83308c2d021b70faebc9