### PR TITLE
Separate look commands and enhance translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ poetry run python game/main.py
 gestartet.
 
 Je nach Spracheingabe können Befehle wie `gehe` (Deutsch) oder `go` (Englisch) eingegeben werden. Mit `beenden` (Deutsch) bzw. `quit` oder `exit` (Englisch) wird das Spiel beendet.
-Gegenstände können mit `nimm`/`take` aufgenommen, mit `lege`/`drop` wieder abgelegt und mit `inventar`/`inventory` angezeigt werden. Mit `umsehen`/`look` lässt sich die Beschreibung des aktuellen Raums erneut ausgeben. Mit `umsehen <gegenstand>`/`look <item>` erhält man die Beschreibung eines Gegenstands. Mit `hilfe`/`help` werden alle verfügbaren Befehle angezeigt. Mit `sprache <id>`/`language <id>` kann die Sprache gewechselt werden.
+Gegenstände können mit `nimm`/`take` aufgenommen, mit `lege`/`drop` wieder abgelegt und mit `inventar`/`inventory` angezeigt werden. Mit `umsehen`/`look` lässt sich die Beschreibung des aktuellen Raums erneut ausgeben. Mit `ansehen <gegenstand>`/`examine <item>` erhält man die Beschreibung eines Gegenstands. Mit `hilfe`/`help` werden alle verfügbaren Befehle angezeigt. Mit `sprache <id>`/`language <id>` kann die Sprache gewechselt werden.
 
 Die sprachunabhängige Weltkonfiguration befindet sich in `data/generic/world.yaml`.
 Sprachspezifische Texte und Bezeichnungen liegen in den Unterverzeichnissen

--- a/data/de/commands.yaml
+++ b/data/de/commands.yaml
@@ -1,16 +1,50 @@
-go: "gehe"
+go:
+  - "gehe"
+  - "geh"
+  - "laufe"
 quit:
   - "beenden"
-take: "nimm"
-drop: "lege"
-drop_suffix: "ab"
-inventory: "inventar"
+  - "ende"
+  - "verlassen"
+take:
+  - "nimm"
+  - "nehme"
+  - "aufheben"
+  - "mitnehmen"
+  - ["heb", "auf"]
+  - ["hebe", "auf"]
+drop:
+  - ["lege", "ab"]
+  - ["lass", "fallen"]
+  - "werfen"
+inventory:
+  - "inventar"
+  - "inv"
 look:
   - "umschau"
   - "umsehen"
-help: "hilfe"
-language: "sprache"
-destroy: "zerstöre"
-wear: "trage"
-use: "benutze"
+  - "umgucken"
+  - "schau"
+  - "sieh dich um"
+examine:
+  - "ansehen"
+  - "schau an"
+  - "betrachte"
+  - "untersuche"
+help:
+  - "hilfe"
+  - "h"
+language:
+  - "sprache"
+destroy:
+  - "zerstöre"
+  - "vernichte"
+wear:
+  - "trage"
+  - "anziehen"
+  - ["zieh", "an"]
+  - ["ziehe", "an"]
+use:
+  - "benutze"
+  - "verwende"
 

--- a/data/en/commands.yaml
+++ b/data/en/commands.yaml
@@ -1,17 +1,50 @@
-go: "go"
+go:
+  - "go"
+  - "move"
+  - "walk"
 quit:
   - "quit"
   - "exit"
-take: "take"
-drop: "drop"
-drop_suffix: ""
-inventory: "inventory"
+  - "leave"
+take:
+  - "take"
+  - "grab"
+  - "pick up"
+  - ["pick", "up"]
+drop:
+  - "drop"
+  - "discard"
+  - "leave"
+  - "put down"
+  - ["put", "down"]
+inventory:
+  - "inventory"
+  - "inv"
 look:
   - "look"
   - "look around"
-help: "help"
-language: "language"
-destroy: "destroy"
-wear: "wear"
-use: "use"
+  - "l"
+  - "scan"
+examine:
+  - "examine"
+  - "look at"
+  - "inspect"
+  - "check"
+help:
+  - "help"
+  - "h"
+language:
+  - "language"
+  - "lang"
+destroy:
+  - "destroy"
+  - "break"
+wear:
+  - "wear"
+  - "equip"
+  - "put on"
+  - ["put", "on"]
+use:
+  - "use"
+  - "apply"
 

--- a/data/generic/commands.yaml
+++ b/data/generic/commands.yaml
@@ -4,6 +4,7 @@
 - drop
 - inventory
 - look
+- examine
 - help
 - language
 - destroy

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -10,7 +10,11 @@ def test_help_lists_commands(data_dir, monkeypatch):
     for key in g.command_keys:
         val = g.commands.get(key)
         if isinstance(val, list):
-            names.append(val[0])
+            first = val[0]
+            if isinstance(first, list):
+                names.append(first[0])
+            else:
+                names.append(first)
         else:
             names.append(val)
     expected = g.messages["help"].format(commands=", ".join(names))

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -8,9 +8,10 @@ def test_language_switch(data_dir, monkeypatch):
     g.cmd_language("de")
     assert g.messages["farewell"] == "Auf Wiedersehen!"
     assert g.commands["look"][0] == "umschau"
-    assert g.reverse_cmds["hilfe"] == "help"
-    assert g.reverse_cmds["language"] == "language"
-    assert g.reverse_cmds["sprache"] == "language"
+    assert g.commands["examine"][0] == "ansehen"
+    assert g.reverse_cmds["hilfe"][0] == "help"
+    assert g.reverse_cmds["language"][0] == "language"
+    assert g.reverse_cmds["sprache"][0] == "language"
     assert outputs[-1] == g.messages["language_set"].format(language="de")
     assert g.world.items["sword"]["names"][0] == "Schwert"
 
@@ -24,14 +25,14 @@ def test_language_persistence(data_dir, monkeypatch):
     g2 = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g2.language == "de"
     assert g2.messages["farewell"] == "Auf Wiedersehen!"
-    assert g2.reverse_cmds["language"] == "language"
+    assert g2.reverse_cmds["language"][0] == "language"
 
 
 def test_language_command_base_word(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "de" / "world.yaml"), "de")
-    cmd = g.reverse_cmds["language"]
+    cmd, _ = g.reverse_cmds["language"]
     getattr(g, f"cmd_{cmd}")("en")
     assert g.language == "en"
     assert outputs[-1] == g.messages["language_set"].format(language="en")

--- a/tests/test_look_item.py
+++ b/tests/test_look_item.py
@@ -6,7 +6,7 @@ def test_look_item_describes(data_dir, monkeypatch):
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
-    g.cmd_look("gem")
+    g.cmd_examine("gem")
     assert outputs[-1] == "A red gem."
 
 
@@ -15,5 +15,5 @@ def test_look_item_not_present(data_dir, monkeypatch):
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
-    g.cmd_look("sword")
+    g.cmd_examine("sword")
     assert outputs[-1] == g.messages["item_not_present"]

--- a/tests/test_suffix.py
+++ b/tests/test_suffix.py
@@ -1,0 +1,16 @@
+from engine import game
+
+
+def test_strip_suffix_drop(data_dir):
+    g = game.Game(str(data_dir / "de" / "world.yaml"), "de")
+    assert g._strip_suffix("stein ab", "ab") == "stein"
+
+
+def test_strip_suffix_wear(data_dir):
+    g = game.Game(str(data_dir / "de" / "world.yaml"), "de")
+    assert g._strip_suffix("hut an", "an") == "hut"
+
+
+def test_strip_suffix_pair(data_dir):
+    g = game.Game(str(data_dir / "de" / "world.yaml"), "de")
+    assert g._strip_suffix("stein fallen", "fallen") == "stein"


### PR DESCRIPTION
## Summary
- Allow command translations to specify synonyms as strings or prefix/suffix pairs
- Parse commands using per-synonym patterns and suffix trimming instead of per-command suffixes
- Update English and German command tables and tests for new flexible structure

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aebcaafb9c8330b1189fb6b63311b6