### PR TITLE
Add startup integrity checks for translations, world data, and saves

### DIFF
--- a/engine/integrity.py
+++ b/engine/integrity.py
@@ -1,0 +1,212 @@
+"""Integrity checks for game data and save files."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List
+
+import yaml
+
+from . import world
+
+
+def check_translations(language: str, data_dir: Path) -> List[str]:
+    """Check translation files for completeness and report warnings.
+
+    Returns a list of warning messages."""
+
+    warnings: List[str] = []
+
+    # Messages ---------------------------------------------------------------
+    base_messages_path = data_dir / "en" / "messages.yaml"
+    lang_messages_path = data_dir / language / "messages.yaml"
+    if base_messages_path.exists() and lang_messages_path.exists():
+        with open(base_messages_path, encoding="utf-8") as fh:
+            base_msgs = yaml.safe_load(fh) or {}
+        with open(lang_messages_path, encoding="utf-8") as fh:
+            lang_msgs = yaml.safe_load(fh) or {}
+        for key in base_msgs:
+            if key not in lang_msgs:
+                warnings.append(f"Missing translation for message '{key}'")
+        for key in lang_msgs:
+            if key not in base_msgs:
+                warnings.append(f"Unused message translation '{key}' ignored")
+
+    # Commands ---------------------------------------------------------------
+    base_cmds_path = data_dir / "generic" / "commands.yaml"
+    lang_cmds_path = data_dir / language / "commands.yaml"
+    if base_cmds_path.exists() and lang_cmds_path.exists():
+        with open(base_cmds_path, encoding="utf-8") as fh:
+            base_cmd_keys = yaml.safe_load(fh) or []
+        with open(lang_cmds_path, encoding="utf-8") as fh:
+            lang_cmds = yaml.safe_load(fh) or {}
+        for key in base_cmd_keys:
+            if key not in lang_cmds:
+                warnings.append(f"Missing translation for command '{key}'")
+        for key in lang_cmds:
+            if key not in base_cmd_keys:
+                warnings.append(f"Unused command translation '{key}' ignored")
+
+    # World translations -----------------------------------------------------
+    base_world_path = data_dir / "generic" / "world.yaml"
+    lang_world_path = data_dir / language / "world.yaml"
+    if base_world_path.exists() and lang_world_path.exists():
+        with open(base_world_path, encoding="utf-8") as fh:
+            base_world = yaml.safe_load(fh) or {}
+        with open(lang_world_path, encoding="utf-8") as fh:
+            lang_world = yaml.safe_load(fh) or {}
+        base_items = base_world.get("items", {})
+        lang_items = lang_world.get("items", {})
+        for item_id in base_items:
+            if item_id not in lang_items:
+                warnings.append(f"Missing translation for item '{item_id}'")
+        for item_id in lang_items:
+            if item_id not in base_items:
+                warnings.append(f"Translation for unused item '{item_id}' ignored")
+        base_rooms = base_world.get("rooms", {})
+        lang_rooms = lang_world.get("rooms", {})
+        for room_id in base_rooms:
+            if room_id not in lang_rooms:
+                warnings.append(f"Missing translation for room '{room_id}'")
+        for room_id in lang_rooms:
+            if room_id not in base_rooms:
+                warnings.append(f"Translation for unused room '{room_id}' ignored")
+
+    return warnings
+
+
+def validate_world_structure(w: world.World) -> List[str]:
+    """Validate cross references inside the world and return error messages."""
+
+    errors: List[str] = []
+
+    # Rooms, exits and items -------------------------------------------------
+    for room_id, room in w.rooms.items():
+        exits = room.get("exits", {})
+        for target in exits:
+            if target not in w.rooms:
+                errors.append(
+                    f"Room '{room_id}' has exit to missing room '{target}'"
+                )
+        for item in room.get("items", []):
+            if item not in w.items:
+                errors.append(
+                    f"Room '{room_id}' contains missing item '{item}'"
+                )
+
+    # Start room -------------------------------------------------------------
+    if w.current not in w.rooms:
+        errors.append(f"Start room '{w.current}' does not exist")
+
+    # Uses -------------------------------------------------------------------
+    for use in w.uses:
+        item = use.get("item")
+        if item and item not in w.items:
+            errors.append(f"Use references missing item '{item}'")
+        target_item = use.get("target_item")
+        if target_item and target_item not in w.items:
+            errors.append(
+                f"Use references missing target item '{target_item}'"
+            )
+        pre = use.get("preconditions", {})
+        loc = pre.get("is_location")
+        if loc and loc not in w.rooms:
+            errors.append(
+                f"Use precondition references missing room '{loc}'"
+            )
+        cond = pre.get("item_condition", {})
+        cond_item = cond.get("item")
+        if cond_item and cond_item not in w.items:
+            errors.append(
+                f"Use precondition references missing item '{cond_item}'"
+            )
+        cond_loc = cond.get("location")
+        if cond_loc and cond_loc != "INVENTORY" and cond_loc not in w.rooms:
+            errors.append(
+                f"Use precondition references missing location '{cond_loc}'"
+            )
+        eff = use.get("effect", {}).get("item_condition", {})
+        eff_item = eff.get("item")
+        if eff_item and eff_item not in w.items:
+            errors.append(
+                f"Use effect references missing item '{eff_item}'"
+            )
+        eff_state = eff.get("state")
+        if eff_item and eff_state and eff_state not in w.items.get(eff_item, {}).get("states", {}):
+            errors.append(
+                f"Use effect references missing state '{eff_state}' for item '{eff_item}'"
+            )
+        eff_loc = eff.get("location")
+        if eff_loc and eff_loc != "INVENTORY" and eff_loc not in w.rooms:
+            errors.append(
+                f"Use effect references missing location '{eff_loc}'"
+            )
+
+    # Endings ----------------------------------------------------------------
+    for end_id, ending in w.endings.items():
+        pre = ending.get("preconditions", {})
+        loc = pre.get("is_location")
+        if loc and loc not in w.rooms:
+            errors.append(
+                f"Ending '{end_id}' precondition references missing room '{loc}'"
+            )
+        cond = pre.get("item_condition", {})
+        cond_item = cond.get("item")
+        if cond_item and cond_item not in w.items:
+            errors.append(
+                f"Ending '{end_id}' references missing item '{cond_item}'"
+            )
+        cond_loc = cond.get("location")
+        if cond_loc and cond_loc != "INVENTORY" and cond_loc not in w.rooms:
+            errors.append(
+                f"Ending '{end_id}' references missing location '{cond_loc}'"
+            )
+        state = cond.get("state")
+        if cond_item and state and state not in w.items.get(cond_item, {}).get("states", {}):
+            errors.append(
+                f"Ending '{end_id}' references missing state '{state}' for item '{cond_item}'"
+            )
+
+    return errors
+
+
+def validate_save(data: Dict[str, Any], w: world.World) -> List[str]:
+    """Validate that a save file only references existing data."""
+
+    errors: List[str] = []
+
+    cur = data.get("current")
+    if cur and cur not in w.rooms:
+        errors.append(f"Save references missing room '{cur}'")
+
+    for item_id in data.get("inventory", []):
+        if item_id not in w.items:
+            errors.append(
+                f"Save references missing item '{item_id}' in inventory"
+            )
+
+    for room_id, items in data.get("rooms", {}).items():
+        if room_id not in w.rooms:
+            errors.append(
+                f"Save references missing room '{room_id}'"
+            )
+        else:
+            for item_id in items or []:
+                if item_id not in w.items:
+                    errors.append(
+                        f"Save references missing item '{item_id}' in room '{room_id}'"
+                    )
+
+    for item_id, state in data.get("item_states", {}).items():
+        if item_id not in w.items:
+            errors.append(
+                f"Save references missing item '{item_id}' in item_states"
+            )
+        else:
+            states = w.items.get(item_id, {}).get("states", {})
+            if state not in states:
+                errors.append(
+                    f"Save references missing state '{state}' for item '{item_id}'"
+                )
+
+    return errors

--- a/engine/world.py
+++ b/engine/world.py
@@ -68,6 +68,17 @@ class World:
             if desc is not None:
                 room["description"] = desc
             rooms[room_id] = room
+        # Ensure items and rooms have at least default translations
+        for item_id, item_cfg in items.items():
+            item_cfg.setdefault("names", [item_id])
+            if "description" not in item_cfg:
+                item_cfg["description"] = item_id
+            states = item_cfg.get("states", {})
+            for state_id, state_cfg in states.items():
+                state_cfg.setdefault("description", state_id)
+        for room_id, room in rooms.items():
+            room.setdefault("names", [room_id])
+            room.setdefault("description", room_id)
         endings: Dict[str, Any] = {}
         base_endings = base.get("endings", {})
         lang_endings = lang.get("endings", {})

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,0 +1,42 @@
+import shutil
+from pathlib import Path
+
+import pytest
+import yaml
+
+from engine import game
+
+
+def copy_data(tmp_path: Path) -> Path:
+    src = Path(__file__).resolve().parents[1] / "data"
+    dest = tmp_path / "data"
+    shutil.copytree(src, dest)
+    return dest
+
+
+def test_invalid_exit_causes_error(tmp_path, capsys):
+    data_dir = copy_data(tmp_path)
+    generic_world_path = data_dir / "generic" / "world.yaml"
+    with open(generic_world_path, encoding="utf-8") as fh:
+        world_data = yaml.safe_load(fh)
+    world_data["rooms"]["ash_village"]["exits"].append("nowhere")
+    with open(generic_world_path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(world_data, fh)
+
+    with pytest.raises(SystemExit):
+        game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    out = capsys.readouterr().out
+    assert "nowhere" in out
+
+
+def test_invalid_save_reference_leaves_file(tmp_path, capsys):
+    data_dir = copy_data(tmp_path)
+    save_path = data_dir / "save.yaml"
+    with open(save_path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump({"current": "ash_village", "inventory": ["unknown"], "language": "en"}, fh)
+
+    with pytest.raises(SystemExit):
+        game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    out = capsys.readouterr().out
+    assert "unknown" in out
+    assert save_path.exists()

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,25 +1,14 @@
-import shutil
-from pathlib import Path
-
 import pytest
 import yaml
 
 from engine import game
 
 
-def copy_data(tmp_path: Path) -> Path:
-    src = Path(__file__).resolve().parents[1] / "data"
-    dest = tmp_path / "data"
-    shutil.copytree(src, dest)
-    return dest
-
-
-def test_invalid_exit_causes_error(tmp_path, capsys):
-    data_dir = copy_data(tmp_path)
+def test_invalid_exit_causes_error(data_dir, capsys):
     generic_world_path = data_dir / "generic" / "world.yaml"
     with open(generic_world_path, encoding="utf-8") as fh:
         world_data = yaml.safe_load(fh)
-    world_data["rooms"]["ash_village"]["exits"].append("nowhere")
+    world_data["rooms"]["start"]["exits"].append("nowhere")
     with open(generic_world_path, "w", encoding="utf-8") as fh:
         yaml.safe_dump(world_data, fh)
 
@@ -29,11 +18,10 @@ def test_invalid_exit_causes_error(tmp_path, capsys):
     assert "nowhere" in out
 
 
-def test_invalid_save_reference_leaves_file(tmp_path, capsys):
-    data_dir = copy_data(tmp_path)
+def test_invalid_save_reference_leaves_file(data_dir, capsys):
     save_path = data_dir / "save.yaml"
     with open(save_path, "w", encoding="utf-8") as fh:
-        yaml.safe_dump({"current": "ash_village", "inventory": ["unknown"], "language": "en"}, fh)
+        yaml.safe_dump({"current": "start", "inventory": ["unknown"], "language": "en"}, fh)
 
     with pytest.raises(SystemExit):
         game.Game(str(data_dir / "en" / "world.yaml"), "en")


### PR DESCRIPTION
## Summary
- validate translation, world, and save data on game startup
- add default fallback text for missing world translations
- cover integrity errors with new tests

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aec6af21988330b006317133db29f4