### PR TITLE
Add NPC state management and events

### DIFF
--- a/engine/game.py
+++ b/engine/game.py
@@ -63,6 +63,7 @@ class Game:
 
     def run(self) -> None:
         io.output(self.world.describe_current(self.messages))
+        self._check_npc_event()
         self._check_end()
         try:
             while self.running:

--- a/engine/integrity.py
+++ b/engine/integrity.py
@@ -142,6 +142,20 @@ def validate_world_structure(w: world.World) -> List[str]:
                 f"Use effect references missing location '{eff_loc}'"
             )
 
+    # NPCs -------------------------------------------------------------------
+    for npc_id, npc in w.npcs.items():
+        meet = npc.get("meet", {})
+        loc = meet.get("location")
+        if loc and loc not in w.rooms:
+            errors.append(
+                f"NPC '{npc_id}' references missing room '{loc}'"
+            )
+        state = npc.get("state")
+        if state and state not in npc.get("states", {}):
+            errors.append(
+                f"NPC '{npc_id}' has undefined state '{state}'"
+            )
+
     # Endings ----------------------------------------------------------------
     for end_id, ending in w.endings.items():
         pre = ending.get("preconditions", {})
@@ -207,6 +221,18 @@ def validate_save(data: Dict[str, Any], w: world.World) -> List[str]:
             if state not in states:
                 errors.append(
                     f"Save references missing state '{state}' for item '{item_id}'"
+                )
+
+    for npc_id, state in data.get("npc_states", {}).items():
+        if npc_id not in w.npcs:
+            errors.append(
+                f"Save references missing NPC '{npc_id}' in npc_states"
+            )
+        else:
+            states = w.npcs.get(npc_id, {}).get("states", {})
+            if state not in states:
+                errors.append(
+                    f"Save references missing state '{state}' for NPC '{npc_id}'"
                 )
 
     return errors

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,13 @@ def data_dir(tmp_path):
             "room2": {"items": ["gem"], "exits": ["start", "room3"]},
             "room3": {"items": ["sword"], "exits": ["start", "room2"]},
         },
+        "npcs": {
+            "old_man": {
+                "state": "unknown",
+                "states": {"unknown": {}, "met": {}},
+                "meet": {"location": "room2"},
+            }
+        },
         "uses": {
             "cut_gem": {
                 "item": "sword",
@@ -60,6 +67,9 @@ def data_dir(tmp_path):
             "room2": {"names": ["Room 2"], "description": "Room 2."},
             "room3": {"names": ["Room 3"], "description": "Room 3."},
         },
+        "npcs": {
+            "old_man": {"meet": {"text": "The old man greets you."}}
+        },
         "uses": {
             "cut_gem": {
                 "success": "The gem now gleams green.",
@@ -86,6 +96,9 @@ def data_dir(tmp_path):
             "start": {"names": ["Raum 1"], "description": "Raum 1."},
             "room2": {"names": ["Raum 2"], "description": "Raum 2."},
             "room3": {"names": ["Raum 3"], "description": "Raum 3."},
+        },
+        "npcs": {
+            "old_man": {"meet": {"text": "Der alte Mann grüßt dich."}}
         },
         "uses": {
             "cut_gem": {

--- a/tests/test_endings.py
+++ b/tests/test_endings.py
@@ -1,5 +1,4 @@
 import yaml
-import pytest
 from engine import game, io
 
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -28,3 +28,16 @@ def test_invalid_save_reference_leaves_file(data_dir, capsys):
     out = capsys.readouterr().out
     assert "unknown" in out
     assert save_path.exists()
+
+
+def test_invalid_npc_location_causes_error(data_dir, capsys):
+    generic_world_path = data_dir / "generic" / "world.yaml"
+    with open(generic_world_path, encoding="utf-8") as fh:
+        world_data = yaml.safe_load(fh)
+    world_data["npcs"]["old_man"]["meet"]["location"] = "nowhere"
+    with open(generic_world_path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(world_data, fh)
+    with pytest.raises(SystemExit):
+        game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    out = capsys.readouterr().out
+    assert "nowhere" in out

--- a/tests/test_npcs.py
+++ b/tests/test_npcs.py
@@ -1,0 +1,50 @@
+import yaml
+from engine.world import World
+from engine import game
+
+
+def make_world() -> World:
+    data = {
+        "npcs": {
+            "old_man": {
+                "state": "unknown",
+                "states": {"unknown": {}, "met": {}},
+            }
+        },
+        "rooms": {"room1": {"description": "Room 1.", "exits": {}}},
+        "start": "room1",
+    }
+    return World(data)
+
+
+def test_meet_npc_changes_state():
+    w = make_world()
+    assert w.npc_state("old_man") == "unknown"
+    assert w.meet_npc("old_man")
+    assert w.npc_state("old_man") == "met"
+
+
+def test_npc_state_saved_and_loaded(tmp_path):
+    w = make_world()
+    w.meet_npc("old_man")
+    save_path = tmp_path / "save.yaml"
+    w.save(save_path)
+    new = make_world()
+    new.load_state(save_path)
+    assert new.npc_state("old_man") == "met"
+    with open(save_path, encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    assert data["npc_states"] == {"old_man": "met"}
+
+
+def test_npc_event_triggered_on_room_change(data_dir, capsys):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    g.cmd_go("Room 2")
+    out = capsys.readouterr().out
+    assert "The old man greets you." in out
+    assert g.world.npc_state("old_man") == "met"
+    g.cmd_go("Room 3")
+    capsys.readouterr()
+    g.cmd_go("Room 2")
+    out = capsys.readouterr().out
+    assert "The old man greets you." not in out


### PR DESCRIPTION
## Summary
- extend world model with NPC definitions, state tracking and meeting functions
- validate NPC references in world and save files
- trigger NPC events on room changes and cover with tests

## Testing
- `ruff check .`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aed8b6acd08330ae6537e5cd2d2c11