### PR TITLE
Reload world data for saved language

### DIFF
--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -26,6 +26,7 @@ def test_language_persistence(data_dir, monkeypatch):
     assert g2.language == "de"
     assert g2.messages["farewell"] == "Auf Wiedersehen!"
     assert g2.reverse_cmds["language"][0] == "language"
+    assert g2.world.items["sword"]["names"][0] == "Schwert"
 
 
 def test_language_command_base_word(data_dir, monkeypatch):


### PR DESCRIPTION
## Summary
- Load language-specific world data based on the saved game language
- Ensure world translations persist after restarting the game

## Testing
- `ruff check .`
- `pyright`
- `pytest tests/test_language.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aeebc8b56883308b7f6390a3b39227