### PR TITLE
Fix item casing for take command

### DIFF
--- a/engine/game.py
+++ b/engine/game.py
@@ -108,9 +108,10 @@ class Game:
         if not arg:
             self.cmd_unknown(arg)
             return
-        item = arg
-        if self.world.take(item):
-            io.output(self.messages["taken"].format(item=item))
+        item_name = arg
+        taken = self.world.take(item_name)
+        if taken:
+            io.output(self.messages["taken"].format(item=taken))
         else:
             io.output(self.messages["item_not_present"])
         self._check_end()

--- a/engine/world.py
+++ b/engine/world.py
@@ -305,7 +305,11 @@ class World:
                 return True
         return False
 
-    def take(self, item_name: str) -> bool:
+    def take(self, item_name: str) -> str | None:
+        """Move an item from the current room into the inventory.
+
+        Returns the canonical item name if the item was taken, otherwise ``None``.
+        """
         room = self.rooms[self.current]
         items = room.get("items", [])
         item_name_cf = item_name.casefold()
@@ -314,8 +318,10 @@ class World:
             if any(name.casefold() == item_name_cf for name in names):
                 items.remove(item_id)
                 self.inventory.append(item_id)
-                return True
-        return False
+                if names:
+                    return names[0]
+                return item_name
+        return None
 
     def drop(self, item_name: str) -> bool:
         item_name_cf = item_name.casefold()

--- a/tests/test_take_command.py
+++ b/tests/test_take_command.py
@@ -1,0 +1,10 @@
+from engine import game, io
+
+
+def test_take_uses_canonical_name(data_dir, monkeypatch):
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    assert g.world.move("Room 3")
+    g.cmd_take("sword")
+    assert outputs[-1] == g.messages["taken"].format(item="Sword")


### PR DESCRIPTION
## Summary
- return canonical item name when taking an item
- use canonical item name in take command output
- add regression test for take command item casing

## Testing
- `ruff check .`
- `pyright`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aefcfee7d08330b9f8206f45fba300