### PR TITLE
NPC-Vorbedingungen für Aktionen prüfen

### DIFF
--- a/engine/world.py
+++ b/engine/world.py
@@ -206,6 +206,13 @@ class World:
                     return False
         return True
 
+    def _check_npc_condition(self, cond: Dict[str, Any]) -> bool:
+        npc_id = cond.get("npc")
+        state = cond.get("state")
+        if not npc_id or not state:
+            return False
+        return self.npc_state(npc_id) == state
+
     def check_preconditions(self, pre: Dict[str, Any] | None) -> bool:
         if not pre:
             return True
@@ -214,6 +221,15 @@ class World:
             return False
         item_cond = pre.get("item_condition")
         if item_cond and not self._check_item_condition(item_cond):
+            return False
+        npc_met = pre.get("npc_met")
+        if npc_met and not self._check_npc_condition({"npc": npc_met, "state": "met"}):
+            return False
+        npc_help = pre.get("npc_help")
+        if npc_help and not self._check_npc_condition({"npc": npc_help, "state": "helped"}):
+            return False
+        npc_cond = pre.get("npc_state")
+        if npc_cond and not self._check_npc_condition(npc_cond):
             return False
         return True
 

--- a/tests/test_npcs.py
+++ b/tests/test_npcs.py
@@ -8,7 +8,7 @@ def make_world() -> World:
         "npcs": {
             "old_man": {
                 "state": "unknown",
-                "states": {"unknown": {}, "met": {}},
+                "states": {"unknown": {}, "met": {}, "helped": {}},
             }
         },
         "rooms": {"room1": {"description": "Room 1.", "exits": {}}},
@@ -82,3 +82,23 @@ def test_npc_event_triggered_on_start(tmp_path, monkeypatch):
     g.run()
 
     assert "Hello there." in outputs
+
+
+def test_action_requires_npc_met():
+    w = make_world()
+    pre = {"npc_met": "old_man"}
+    assert not w.check_preconditions(pre)
+    w.meet_npc("old_man")
+    assert w.check_preconditions(pre)
+
+
+def test_action_requires_npc_help():
+    w = make_world()
+    pre_help = {"npc_help": "old_man"}
+    pre_state = {"npc_state": {"npc": "old_man", "state": "helped"}}
+    assert not w.check_preconditions(pre_help)
+    assert not w.check_preconditions(pre_state)
+    w.npc_states["old_man"] = "helped"
+    w.npcs["old_man"]["state"] = "helped"
+    assert w.check_preconditions(pre_help)
+    assert w.check_preconditions(pre_state)


### PR DESCRIPTION
## Zusammenfassung
- Prüft in `World.check_preconditions` nun auch NPC-Zustände (`npc_met`, `npc_help`, `npc_state`).
- Fügt Tests hinzu, die Aktionen nur nach erfüllten NPC-Vorbedingungen erlauben.

## Testing
- `ruff check .`
- `pyright`
- `pytest` *(Coverage wegen fehlender Erweiterung nicht verfügbar)*

------
https://chatgpt.com/codex/tasks/task_e_68af4bdc1718833096270f68872da3be