### PR TITLE
Add debug mode with state logging

### DIFF
--- a/game/main.py
+++ b/game/main.py
@@ -2,6 +2,7 @@
 
 from pathlib import Path
 import sys
+import argparse
 
 # Ensure repository root is on the path when executed directly
 sys.path.append(str(Path(__file__).resolve().parent.parent))
@@ -10,6 +11,9 @@ from engine.game import run
 
 
 if __name__ == "__main__":
-    language = "de"
-    data_path = Path(__file__).parent.parent / "data" / language / "world.yaml"
-    run(str(data_path), language=language)
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--language", default="de")
+    parser.add_argument("--debug", action="store_true")
+    args = parser.parse_args()
+    data_path = Path(__file__).parent.parent / "data" / args.language / "world.yaml"
+    run(str(data_path), language=args.language, debug=args.debug)

--- a/tests/test_debug_mode.py
+++ b/tests/test_debug_mode.py
@@ -1,0 +1,23 @@
+from engine import game
+
+
+def test_debug_outputs_after_state_changes(data_dir, capsys):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", debug=True)
+    capsys.readouterr()
+    g.cmd_go("Room 2")
+    err = capsys.readouterr().err
+    assert "-- location room2" in err
+    assert "-- npc old_man state met" in err
+
+    g.cmd_take("Gem")
+    err = capsys.readouterr().err
+    assert "-- inventory ['gem']" in err
+    assert "-- room room2 items []" in err
+
+    g.world.set_item_state("gem", "green")
+    err = capsys.readouterr().err
+    assert "-- item gem state green" in err
+
+    g.world.set_npc_state("old_man", "helped")
+    err = capsys.readouterr().err
+    assert "-- npc old_man state helped" in err


### PR DESCRIPTION
## Summary
- add --debug option to CLI and Game constructor
- log room, item, and NPC state changes to stderr when debug is enabled
- cover debug output with unit tests

## Testing
- `ruff check .`
- `pyright`
- `pytest`
- `pytest --cov` *(fails: pytest: error: unrecognized arguments: --cov)*
- `pip install pytest-cov` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af51ecaca88330bde615363809af89