### PR TITLE
Require NPC name for talk command and support multiple item condition effects

### DIFF
--- a/data/generic/world.yaml
+++ b/data/generic/world.yaml
@@ -53,23 +53,23 @@ uses:
       is_location: ruins
     effect:
       item_condition:
-        item: locked_chest
-        state: open
+        - item: locked_chest
+          state: open
   interpret_map:
     item: map_fragment
     preconditions:
       npc_met: ashram
     effect:
       item_condition:
-        item: map_fragment
-        state: readable
+        - item: map_fragment
+          state: readable
   open_ruins:
     preconditions:
       npc_help: ashram
     effect:
       item_condition:
-        item: ashen_crown
-        location: ruins
+        - item: ashen_crown
+          location: ruins
 
 start: hut
 

--- a/engine/game.py
+++ b/engine/game.py
@@ -249,13 +249,18 @@ class Game:
         io.output(self.messages["language_set"].format(language=language))
 
     def cmd_talk(self, arg: str) -> None:
-        if arg:
+        if not arg:
             self.cmd_unknown(arg)
             return
+        npc_name_cf = arg.casefold()
         for npc_id, npc in self.world.npcs.items():
+            names = npc.get("names", [])
+            if not any(name.casefold() == npc_name_cf for name in names):
+                continue
             meet = npc.get("meet", {})
             if meet.get("location") != self.world.current:
-                continue
+                io.output(self.messages["no_npc"])
+                return
             state = self.world.npc_state(npc_id)
             states = npc.get("states", {})
             talk_cfg = states.get(state, {})

--- a/engine/integrity.py
+++ b/engine/integrity.py
@@ -125,22 +125,25 @@ def validate_world_structure(w: world.World) -> List[str]:
             errors.append(
                 f"Use precondition references missing location '{cond_loc}'"
             )
-        eff = use.get("effect", {}).get("item_condition", {})
-        eff_item = eff.get("item")
-        if eff_item and eff_item not in w.items:
-            errors.append(
-                f"Use effect references missing item '{eff_item}'"
-            )
-        eff_state = eff.get("state")
-        if eff_item and eff_state and eff_state not in w.items.get(eff_item, {}).get("states", {}):
-            errors.append(
-                f"Use effect references missing state '{eff_state}' for item '{eff_item}'"
-            )
-        eff_loc = eff.get("location")
-        if eff_loc and eff_loc != "INVENTORY" and eff_loc not in w.rooms:
-            errors.append(
-                f"Use effect references missing location '{eff_loc}'"
-            )
+        eff = use.get("effect", {}).get("item_condition", [])
+        if isinstance(eff, dict):
+            eff = [eff]
+        for cond in eff:
+            eff_item = cond.get("item")
+            if eff_item and eff_item not in w.items:
+                errors.append(
+                    f"Use effect references missing item '{eff_item}'"
+                )
+            eff_state = cond.get("state")
+            if eff_item and eff_state and eff_state not in w.items.get(eff_item, {}).get("states", {}):
+                errors.append(
+                    f"Use effect references missing state '{eff_state}' for item '{eff_item}'"
+                )
+            eff_loc = cond.get("location")
+            if eff_loc and eff_loc != "INVENTORY" and eff_loc not in w.rooms:
+                errors.append(
+                    f"Use effect references missing location '{eff_loc}'"
+                )
 
     # NPCs -------------------------------------------------------------------
     for npc_id, npc in w.npcs.items():

--- a/engine/world.py
+++ b/engine/world.py
@@ -268,8 +268,12 @@ class World:
 
     def apply_effect(self, effect: Dict[str, Any]) -> None:
         item_cond = effect.get("item_condition")
-        if item_cond:
-            self.apply_item_condition(item_cond)
+        if not item_cond:
+            return
+        if isinstance(item_cond, dict):
+            item_cond = [item_cond]
+        for cond in item_cond:
+            self.apply_item_condition(cond)
 
     def describe_current(self, messages: Dict[str, str] | None = None) -> str:
         room = self.rooms[self.current]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ def data_dir(tmp_path):
                 "target_item": "gem",
                 "preconditions": {"is_location": "room2"},
                 "effect": {
-                    "item_condition": {"item": "gem", "state": "green"}
+                    "item_condition": [{"item": "gem", "state": "green"}]
                 },
             }
         },

--- a/tests/test_effect_item_conditions.py
+++ b/tests/test_effect_item_conditions.py
@@ -1,0 +1,18 @@
+from engine import game
+
+
+def test_apply_effect_multiple_item_conditions(data_dir):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    assert "sword" in g.world.rooms["room3"]["items"]
+    g.world.apply_effect(
+        {
+            "item_condition": [
+                {"item": "gem", "state": "green"},
+                {"item": "sword", "location": "INVENTORY"},
+            ]
+        }
+    )
+    assert g.world.item_states["gem"] == "green"
+    assert "sword" in g.world.inventory
+    assert "sword" not in g.world.rooms["room3"]["items"]
+

--- a/tests/test_talk_command.py
+++ b/tests/test_talk_command.py
@@ -1,14 +1,23 @@
 from engine import game
 
 
-def test_talk_changes_state_and_outputs_text(data_dir, capsys):
+def test_talk_requires_npc_name(data_dir, capsys):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     g.cmd_go("Room 2")
     capsys.readouterr()
     g.cmd_talk("")
     out = capsys.readouterr().out
+    assert "I didn't understand that." in out
+
+
+def test_talk_changes_state_and_outputs_text(data_dir, capsys):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    g.cmd_go("Room 2")
+    capsys.readouterr()
+    g.cmd_talk("Old Man")
+    out = capsys.readouterr().out
     assert "You tell the old man about your quest. He agrees to help." in out
     assert g.world.npc_state("old_man") == "helped"
-    g.cmd_talk("")
+    g.cmd_talk("Old Man")
     out = capsys.readouterr().out
     assert "The old man has already offered his aid." in out


### PR DESCRIPTION
## Summary
- Enforce specifying an NPC name when talking
- Allow effects to apply a list of item condition changes
- Add test exercising multiple item condition effects

## Testing
- `ruff check .`
- `pyright`
- `pytest --cov` *(fails: ModuleNotFoundError: No module named 'yaml'; `pip install pyyaml` also failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68af61c6e1fc8330967a8d8f432184b2