### PR TITLE
Allow translation of 'use' preposition

### DIFF
--- a/data/de/commands.yaml
+++ b/data/de/commands.yaml
@@ -1,53 +1,52 @@
 go:
-  - "gehe"
-  - "geh"
-  - "laufe"
+  - 'gehe $a'
+  - 'geh $a'
+  - 'laufe $a'
 quit:
-  - "beenden"
-  - "ende"
-  - "verlassen"
+  - 'beenden'
+  - 'ende'
+  - 'verlassen'
 take:
-  - "nimm"
-  - "nehme"
-  - "aufheben"
-  - "mitnehmen"
-  - ["heb", "auf"]
-  - ["hebe", "auf"]
+  - 'nimm $a'
+  - 'nehme $a'
+  - 'heb $a auf'
+  - 'hebe $a auf'
 drop:
-  - ["lege", "ab"]
-  - ["lass", "fallen"]
-  - "werfen"
+  - 'lege $a ab'
+  - 'lass $a fallen'
+  - 'wirf $a weg'
 inventory:
-  - "inventar"
-  - "inv"
+  - 'inventar'
+  - 'inv'
 look:
-  - "umschau"
-  - "umsehen"
-  - "umgucken"
-  - "schau"
-  - "sieh dich um"
+  - 'umschau'
+  - 'umsehen'
+  - 'umgucken'
+  - 'schau'
+  - 'sieh dich um'
 examine:
-  - "ansehen"
-  - "schau an"
-  - "betrachte"
-  - "untersuche"
+  - 'ansehen $a'
+  - 'schau $a an'
+  - 'betrachte $a'
+  - 'untersuche $a'
 help:
-  - "hilfe"
-  - "h"
+  - 'hilfe'
+  - 'h'
+  - 'hilfe $a'
+  - 'h $a'
 language:
-  - "sprache"
+  - 'sprache $a'
 destroy:
-  - "zerstöre"
-  - "vernichte"
+  - 'zerstöre $a'
+  - 'vernichte $a'
 wear:
-  - "trage"
-  - "anziehen"
-  - ["zieh", "an"]
-  - ["ziehe", "an"]
+  - 'trage $a'
+  - 'zieh $a an'
+  - 'ziehe $a an'
 use:
-  - "benutze"
-  - "verwende"
+  - 'benutze $a mit $b'
+  - 'verwende $a für $b'
 talk:
-  - "rede"
-  - "sprich"
+  - 'rede $a'
+  - 'sprich $a'
 

--- a/data/en/commands.yaml
+++ b/data/en/commands.yaml
@@ -1,53 +1,52 @@
 go:
-  - "go"
-  - "move"
-  - "walk"
+  - 'go $a'
+  - 'move $a'
+  - 'walk $a'
 quit:
-  - "quit"
-  - "exit"
-  - "leave"
+  - 'quit'
+  - 'exit'
+  - 'leave'
 take:
-  - "take"
-  - "grab"
-  - "pick up"
-  - ["pick", "up"]
+  - 'take $a'
+  - 'grab $a'
+  - 'pick up $a'
 drop:
-  - "drop"
-  - "discard"
-  - "leave"
-  - "put down"
-  - ["put", "down"]
+  - 'drop $a'
+  - 'discard $a'
+  - 'leave $a'
+  - 'put down $a'
 inventory:
-  - "inventory"
-  - "inv"
+  - 'inventory'
+  - 'inv'
 look:
-  - "look"
-  - "look around"
-  - "l"
-  - "scan"
+  - 'look'
+  - 'look around'
+  - 'l'
+  - 'scan'
 examine:
-  - "examine"
-  - "look at"
-  - "inspect"
-  - "check"
+  - 'examine $a'
+  - 'look at $a'
+  - 'inspect $a'
+  - 'check $a'
 help:
-  - "help"
-  - "h"
+  - 'help'
+  - 'h'
+  - 'help $a'
+  - 'h $a'
 language:
-  - "language"
-  - "lang"
+  - 'language $a'
+  - 'lang $a'
 destroy:
-  - "destroy"
-  - "break"
+  - 'destroy $a'
+  - 'break $a'
 wear:
-  - "wear"
-  - "equip"
-  - "put on"
-  - ["put", "on"]
+  - 'wear $a'
+  - 'equip $a'
+  - 'put on $a'
 use:
-  - "use"
-  - "apply"
+  - 'use $a on $b'
+  - 'apply $a to $b'
 talk:
-  - "talk"
-  - "speak"
+  - 'talk $a'
+  - 'speak $a'
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -8,15 +8,10 @@ def test_help_lists_commands(data_dir, monkeypatch):
     g.cmd_help("")
     names = []
     for key in g.command_keys:
-        val = g.commands.get(key)
-        if isinstance(val, list):
-            first = val[0]
-            if isinstance(first, list):
-                names.append(first[0])
-            else:
-                names.append(first)
-        else:
-            names.append(val)
+        val = g.commands.get(key, [])
+        entries = val if isinstance(val, list) else [val]
+        first = entries[0]
+        names.append(first.split()[0])
     expected = g.messages["help"].format(commands=", ".join(names))
     assert outputs[-1] == expected
 
@@ -27,14 +22,7 @@ def test_help_lists_synonyms(data_dir, monkeypatch):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     g.cmd_help("destroy")
     entries = g.commands["destroy"]
-    arg_str = " ".join("<>" for _ in range(g.command_info["destroy"].get("arguments", 0)))
-    usages = []
-    for entry in entries:
-        if isinstance(entry, list):
-            name, suffix = entry
-            usages.append(f"{name} {arg_str} {suffix}".strip())
-        else:
-            usages.append(f"{entry} {arg_str}".strip())
+    usages = [e.replace("$a", "<>").replace("$b", "<>") for e in entries]
     expected = (
         g.messages["help_usage"].format(command="destroy")
         + "\n"
@@ -50,6 +38,6 @@ def test_help_optional_argument(data_dir, monkeypatch):
     g.cmd_help("help")
     expected = (
         g.messages["help_usage"].format(command="help")
-        + "\nhelp <command>\nh <command>"
+        + "\nhelp <>\nh <>"
     )
     assert outputs[-1] == expected

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -8,7 +8,7 @@ def test_language_switch(data_dir, monkeypatch):
     g.cmd_language("de")
     assert g.messages["farewell"] == "Auf Wiedersehen!"
     assert g.commands["look"][0] == "umschau"
-    assert g.commands["examine"][0] == "ansehen"
+    assert g.commands["examine"][0] == "ansehen $a"
     assert g.reverse_cmds["hilfe"][0] == "help"
     assert g.reverse_cmds["language"][0] == "language"
     assert g.reverse_cmds["sprache"][0] == "language"

--- a/tests/test_playthrough.py
+++ b/tests/test_playthrough.py
@@ -24,26 +24,19 @@ def test_game_reaches_ending(data_dir, monkeypatch):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
 
     commands = [
-        "take Small Key",
-        "go Forest",
-        "take Map Fragment",
-        "go Ruins",
-        "take Locked Chest",
-        "use Small Key on Locked Chest",
-        "effect open_ruins",
-        "take Ashen Crown",
-        "go Forest",
-        "go Ash Village",
+        lambda: g.cmd_take("Small Key"),
+        lambda: g.cmd_go("Forest"),
+        lambda: g.cmd_take("Map Fragment"),
+        lambda: g.cmd_go("Ruins"),
+        lambda: g.cmd_take("Locked Chest"),
+        lambda: g.cmd_use("Small Key", "Locked Chest"),
+        lambda: (g.world.apply_effect(open_ruins_effect), io.output(open_ruins_message)),
+        lambda: g.cmd_take("Ashen Crown"),
+        lambda: g.cmd_go("Forest"),
+        lambda: g.cmd_go("Ash Village"),
     ]
 
-    for entry in commands:
-        parts = entry.split(" ", 1)
-        cmd = parts[0]
-        arg = parts[1] if len(parts) > 1 else ""
-        if cmd == "effect":
-            g.world.apply_effect(open_ruins_effect)
-            io.output(open_ruins_message)
-        else:
-            getattr(g, f"cmd_{cmd}")(arg)
+    for func in commands:
+        func()
 
     assert outputs[-1] == ending_text

--- a/tests/test_use_command.py
+++ b/tests/test_use_command.py
@@ -9,7 +9,7 @@ def test_use_success(data_dir, monkeypatch):
     assert g.world.take("Sword")
     assert g.world.move("Room 2")
     assert g.world.take("Gem")
-    g.cmd_use("Sword on Gem")
+    g.cmd_use("Sword", "Gem")
     assert g.world.item_states["gem"] == "green"
     success_msg = next(
         u["success"]
@@ -28,7 +28,7 @@ def test_use_invalid(data_dir, monkeypatch):
     assert g.world.move("Room 2")
     assert g.world.take("Gem")
     assert g.world.move("Room 3")
-    g.cmd_use("Sword on Gem")
+    g.cmd_use("Sword", "Gem")
     assert g.world.item_states["gem"] == "red"
     assert outputs[-1] == g.messages["use_failure"]
 


### PR DESCRIPTION
## Summary
- add command placeholders so verbs and prepositions are translated
- parse localized command patterns with regex
- split `use` into separate item and target arguments

## Testing
- `ruff check .`
- `pyright`
- `pytest --cov` *(fails: No module named 'yaml')*


------
https://chatgpt.com/codex/tasks/task_e_68afea659d948330b95f283889900828