### PR TITLE
Refactor uses into action triggers

### DIFF
--- a/data/de/world.yaml
+++ b/data/de/world.yaml
@@ -63,13 +63,16 @@ npcs:
       helped:
         talk: "Ashram nickt; er unterstützt dich bereits."
 
-uses:
-  use_key:
-    success: "Der Schlüssel klickt, und die Truhe entriegelt sich."
+actions:
+  open_chest:
+    messages:
+      success: "Der Schlüssel klickt, und die Truhe entriegelt sich."
   interpret_map:
-    success: "Ashram hilft dir, die verblasste Karte zu entziffern."
+    messages:
+      success: "Ashram hilft dir, die verblasste Karte zu entziffern."
   open_ruins:
-    success: "Mit Ashrams Hilfe offenbaren die Ruinen eine verborgene Kammer."
+    messages:
+      success: "Mit Ashrams Hilfe offenbaren die Ruinen eine verborgene Kammer."
 
 endings:
   crown_returned: "Mit der Aschenkrone kehrst du ins Dorf zurück und erfüllst dein Schicksal."

--- a/data/en/world.yaml
+++ b/data/en/world.yaml
@@ -63,13 +63,16 @@ npcs:
       helped:
         talk: "Ashram nods; he is already helping you."
 
-uses:
-  use_key:
-    success: "The key turns with a click and the chest unlocks."
+actions:
+  open_chest:
+    messages:
+      success: "The key turns with a click and the chest unlocks."
   interpret_map:
-    success: "Ashram helps you decipher the faded map."
+    messages:
+      success: "Ashram helps you decipher the faded map."
   open_ruins:
-    success: "With Ashram's aid the ruins reveal a hidden chamber."
+    messages:
+      success: "With Ashram's aid the ruins reveal a hidden chamber."
 
 endings:
   crown_returned: "With the Ashen Crown reclaimed, you return to the village as its destined ruler."

--- a/data/generic/world.yaml
+++ b/data/generic/world.yaml
@@ -45,8 +45,9 @@ npcs:
     meet:
       location: forest
 
-uses:
-  use_key:
+actions:
+  open_chest:
+    trigger: use
     item: small_key
     target_item: locked_chest
     preconditions:
@@ -56,6 +57,7 @@ uses:
         - item: locked_chest
           state: open
   interpret_map:
+    trigger: use
     item: map_fragment
     preconditions:
       npc_met: ashram
@@ -64,6 +66,7 @@ uses:
         - item: map_fragment
           state: readable
   open_ruins:
+    trigger: use
     preconditions:
       npc_help: ashram
     effect:

--- a/engine/game.py
+++ b/engine/game.py
@@ -288,13 +288,15 @@ class Game:
             io.output(self.messages["use_failure"])
             self._check_end()
             return
-        for use in self.world.uses:
-            if use.get("item") == item_id and use.get("target_item") == target_id:
-                if not self.world.check_preconditions(use.get("preconditions")):
+        for action in self.world.actions:
+            if action.get("trigger") != "use":
+                continue
+            if action.get("item") == item_id and action.get("target_item") == target_id:
+                if not self.world.check_preconditions(action.get("preconditions")):
                     continue
-                effect = use.get("effect", {})
+                effect = action.get("effect", {})
                 self.world.apply_effect(effect)
-                message = use.get("success")
+                message = action.get("messages", {}).get("success")
                 if message:
                     io.output(message)
                 else:

--- a/engine/integrity.py
+++ b/engine/integrity.py
@@ -98,51 +98,56 @@ def validate_world_structure(w: world.World) -> List[str]:
     if w.current not in w.rooms:
         errors.append(f"Start room '{w.current}' does not exist")
 
-    # Uses -------------------------------------------------------------------
-    for use in w.uses:
-        item = use.get("item")
+    # Actions ----------------------------------------------------------------
+    for action in w.actions:
+        trigger = action.get("trigger")
+        if not trigger:
+            errors.append("Action missing trigger")
+        if trigger != "use":
+            continue
+        item = action.get("item")
         if item and item not in w.items:
-            errors.append(f"Use references missing item '{item}'")
-        target_item = use.get("target_item")
+            errors.append(f"Action references missing item '{item}'")
+        target_item = action.get("target_item")
         if target_item and target_item not in w.items:
             errors.append(
-                f"Use references missing target item '{target_item}'"
+                f"Action references missing target item '{target_item}'"
             )
-        pre = use.get("preconditions", {})
+        pre = action.get("preconditions", {})
         loc = pre.get("is_location")
         if loc and loc not in w.rooms:
             errors.append(
-                f"Use precondition references missing room '{loc}'"
+                f"Action precondition references missing room '{loc}'"
             )
         cond = pre.get("item_condition", {})
         cond_item = cond.get("item")
         if cond_item and cond_item not in w.items:
             errors.append(
-                f"Use precondition references missing item '{cond_item}'"
+                f"Action precondition references missing item '{cond_item}'"
             )
         cond_loc = cond.get("location")
         if cond_loc and cond_loc != "INVENTORY" and cond_loc not in w.rooms:
             errors.append(
-                f"Use precondition references missing location '{cond_loc}'"
+                f"Action precondition references missing location '{cond_loc}'"
             )
-        eff = use.get("effect", {}).get("item_condition", [])
+        eff = action.get("effect", {}).get("item_condition", [])
         if isinstance(eff, dict):
             eff = [eff]
         for cond in eff:
             eff_item = cond.get("item")
             if eff_item and eff_item not in w.items:
                 errors.append(
-                    f"Use effect references missing item '{eff_item}'"
+                    f"Action effect references missing item '{eff_item}'"
                 )
             eff_state = cond.get("state")
             if eff_item and eff_state and eff_state not in w.items.get(eff_item, {}).get("states", {}):
                 errors.append(
-                    f"Use effect references missing state '{eff_state}' for item '{eff_item}'"
+                    f"Action effect references missing state '{eff_state}' for item '{eff_item}'"
                 )
             eff_loc = cond.get("location")
             if eff_loc and eff_loc != "INVENTORY" and eff_loc not in w.rooms:
                 errors.append(
-                    f"Use effect references missing location '{eff_loc}'"
+                    f"Action effect references missing location '{eff_loc}'"
                 )
 
     # NPCs -------------------------------------------------------------------

--- a/engine/world.py
+++ b/engine/world.py
@@ -16,7 +16,7 @@ class World:
         self.current = data["start"]
         self.inventory: list[str] = data.get("inventory", [])
         self.endings = data.get("endings", {})
-        self.uses: list[Dict[str, Any]] = data.get("uses", [])
+        self.actions: list[Dict[str, Any]] = data.get("actions", [])
         self.item_states: Dict[str, str] = {
             item_id: item_data.get("state")
             for item_id, item_data in self.items.items()
@@ -105,13 +105,13 @@ class World:
             elif lang_cfg is not None:
                 ending["description"] = lang_cfg
             endings[end_id] = ending
-        uses: list[Dict[str, Any]] = []
-        base_uses = base.get("uses", {})
-        lang_uses = lang.get("uses", {})
-        for use_id, cfg_use in base_uses.items():
-            use = dict(cfg_use)
-            use.update(lang_uses.get(use_id, {}))
-            uses.append(use)
+        actions: list[Dict[str, Any]] = []
+        base_actions = base.get("actions", {})
+        lang_actions = lang.get("actions", {})
+        for action_id, cfg_action in base_actions.items():
+            action = dict(cfg_action)
+            action.update(lang_actions.get(action_id, {}))
+            actions.append(action)
         npcs: Dict[str, Any] = base.get("npcs", {})
         lang_npcs = lang.get("npcs", {})
         for npc_id, npc_data in lang_npcs.items():
@@ -133,7 +133,7 @@ class World:
             "rooms": rooms,
             "start": base["start"],
             "endings": endings,
-            "uses": uses,
+            "actions": actions,
             "npcs": npcs,
         }
         return cls(data, debug=debug)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,9 @@ def data_dir(tmp_path):
                 "meet": {"location": "room2"},
             }
         },
-        "uses": {
+        "actions": {
             "cut_gem": {
+                "trigger": "use",
                 "item": "sword",
                 "target_item": "gem",
                 "preconditions": {"is_location": "room2"},
@@ -81,9 +82,11 @@ def data_dir(tmp_path):
                 },
             }
         },
-        "uses": {
+        "actions": {
             "cut_gem": {
-                "success": "The gem now gleams green.",
+                "messages": {
+                    "success": "The gem now gleams green."
+                }
             }
         },
         "endings": {"green_gem": "The gem is green."},
@@ -122,9 +125,11 @@ def data_dir(tmp_path):
                 },
             }
         },
-        "uses": {
+        "actions": {
             "cut_gem": {
-                "success": "Das Juwel leuchtet jetzt grün.",
+                "messages": {
+                    "success": "Das Juwel leuchtet jetzt grün."
+                }
             }
         },
         "endings": {"green_gem": "Das Juwel ist grün."},

--- a/tests/test_playthrough.py
+++ b/tests/test_playthrough.py
@@ -14,8 +14,8 @@ def test_game_reaches_ending(data_dir, monkeypatch):
     with open(data_dir / "en" / "world.yaml", encoding="utf-8") as fh:
         en = yaml.safe_load(fh)
 
-    open_ruins_effect = generic["uses"]["open_ruins"]["effect"]
-    open_ruins_message = en["uses"]["open_ruins"]["success"]
+    open_ruins_effect = generic["actions"]["open_ruins"]["effect"]
+    open_ruins_message = en["actions"]["open_ruins"]["messages"]["success"]
     ending_text = en["endings"]["crown_returned"]
 
     outputs: list[str] = []

--- a/tests/test_use_command.py
+++ b/tests/test_use_command.py
@@ -12,9 +12,11 @@ def test_use_success(data_dir, monkeypatch):
     g.cmd_use("Sword", "Gem")
     assert g.world.item_states["gem"] == "green"
     success_msg = next(
-        u["success"]
-        for u in g.world.uses
-        if u.get("item") == "sword" and u.get("target_item") == "gem"
+        a["messages"]["success"]
+        for a in g.world.actions
+        if a.get("trigger") == "use"
+        and a.get("item") == "sword"
+        and a.get("target_item") == "gem"
     )
     assert outputs[-2:] == [success_msg, "The gem is green."]
 


### PR DESCRIPTION
## Summary
- Replace `uses` with `actions` and add `trigger: use` rules
- Update German and English world data to the new `actions`/`messages` layout
- Adjust engine, integrity checks, and tests to handle action-based triggers

## Testing
- `ruff check engine tests`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b045c92f04833090b556e537dd1437