### PR TITLE
Validate action translations

### DIFF
--- a/engine/integrity.py
+++ b/engine/integrity.py
@@ -71,6 +71,18 @@ def check_translations(language: str, data_dir: Path) -> List[str]:
         for room_id in lang_rooms:
             if room_id not in base_rooms:
                 warnings.append(f"Translation for unused room '{room_id}' ignored")
+        base_actions = base_world.get("actions", {})
+        lang_actions = lang_world.get("actions", {})
+        for action_id in base_actions:
+            if action_id not in lang_actions:
+                warnings.append(
+                    f"Missing translation for action '{action_id}'"
+                )
+        for action_id in lang_actions:
+            if action_id not in base_actions:
+                warnings.append(
+                    f"Translation for unused action '{action_id}' ignored"
+                )
 
     return warnings
 

--- a/engine/world.py
+++ b/engine/world.py
@@ -16,7 +16,10 @@ class World:
         self.current = data["start"]
         self.inventory: list[str] = data.get("inventory", [])
         self.endings = data.get("endings", {})
-        self.actions: list[Dict[str, Any]] = data.get("actions", [])
+        actions = data.get("actions", [])
+        if isinstance(actions, dict):
+            actions = list(actions.values())
+        self.actions: list[Dict[str, Any]] = list(actions)
         self.item_states: Dict[str, str] = {
             item_id: item_data.get("state")
             for item_id, item_data in self.items.items()
@@ -42,6 +45,9 @@ class World:
     def from_file(cls, path: str | Path, debug: bool = False) -> "World":
         with open(path, encoding="utf-8") as fh:
             data = yaml.safe_load(fh)
+        actions = data.get("actions", {})
+        if isinstance(actions, dict):
+            data["actions"] = list(actions.values())
         return cls(data, debug=debug)
 
     @classmethod

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,7 +1,7 @@
 import pytest
 import yaml
 
-from engine import game
+from engine import game, io
 
 
 def test_invalid_exit_causes_error(data_dir, capsys):
@@ -41,3 +41,16 @@ def test_invalid_npc_location_causes_error(data_dir, capsys):
         game.Game(str(data_dir / "en" / "world.yaml"), "en")
     out = capsys.readouterr().out
     assert "nowhere" in out
+
+
+def test_missing_action_translation_warns(data_dir, monkeypatch):
+    en_path = data_dir / "en" / "world.yaml"
+    with open(en_path, encoding="utf-8") as fh:
+        en_world = yaml.safe_load(fh)
+    en_world["actions"].pop("cut_gem")
+    with open(en_path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(en_world, fh)
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    assert any("Missing translation for action 'cut_gem'" in o for o in outputs)


### PR DESCRIPTION
## Summary
- Normalize actions in `World` so both dict and list inputs load consistently
- Warn about missing or unused action translations during integrity checks
- Test warning emission for absent action translations

## Testing
- `ruff engine tests`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0497575b88330b4fde146ea5500be