### PR TITLE
Add generic action resolver and CURRENT_ROOM placeholder

### DIFF
--- a/engine/world.py
+++ b/engine/world.py
@@ -250,6 +250,8 @@ class World:
             self.set_item_state(item_id, state)
         location = cond.get("location")
         if location:
+            if location == "CURRENT_ROOM":
+                location = self.current
             if item_id in self.inventory:
                 self.inventory.remove(item_id)
                 self.debug(f"inventory {self.inventory}")

--- a/game/main.py
+++ b/game/main.py
@@ -7,7 +7,7 @@ import argparse
 # Ensure repository root is on the path when executed directly
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 
-from engine.game import run
+from engine.game import run  # noqa: E402
 
 
 if __name__ == "__main__":

--- a/tests/test_examine_action.py
+++ b/tests/test_examine_action.py
@@ -1,0 +1,26 @@
+from engine import game, io
+
+
+def test_examine_triggers_action(data_dir, monkeypatch):
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+
+    g.world.items["stone"] = {"names": ["Stone"], "description": "A stone."}
+    g.world.items["coin"] = {"names": ["Coin"], "description": "A coin."}
+    g.world.rooms["start"].setdefault("items", []).append("stone")
+    g.world.actions.append(
+        {
+            "trigger": "examine",
+            "item": "stone",
+            "effect": {
+                "item_condition": {"item": "coin", "location": "CURRENT_ROOM"}
+            },
+            "messages": {"success": "You find a coin."},
+        }
+    )
+
+    g.describe_item("Stone")
+
+    assert outputs[-2:] == ["A stone.", "You find a coin."]
+    assert "coin" in g.world.rooms[g.world.current].get("items", [])


### PR DESCRIPTION
## Summary
- Add generic action execution in the game engine
- Refactor `use` and `examine` commands to run configured actions
- Support `CURRENT_ROOM` placeholder when resolving item effects

## Testing
- `ruff .`
- `pyright`
- `pytest --cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68b0499b17688330b75c764e150a2e7a