### PR TITLE
Allow using items from inventory or room

### DIFF
--- a/engine/game.py
+++ b/engine/game.py
@@ -317,8 +317,8 @@ class Game:
         if not item_name or not target_name:
             self.cmd_unknown("use")
             return
-        item_id = self._find_item_id(item_name, in_inventory=True)
-        target_id = self._find_item_id(target_name, in_inventory=True)
+        item_id = self._find_item_id(item_name)
+        target_id = self._find_item_id(target_name)
         if not item_id or not target_id:
             io.output(self.messages["use_failure"])
             self._check_end()

--- a/tests/test_use_command.py
+++ b/tests/test_use_command.py
@@ -8,7 +8,28 @@ def test_use_success(data_dir, monkeypatch):
     assert g.world.move("Room 3")
     assert g.world.take("Sword")
     assert g.world.move("Room 2")
+    g.cmd_use("Sword", "Gem")
+    assert g.world.item_states["gem"] == "green"
+    success_msg = next(
+        a["messages"]["success"]
+        for a in g.world.actions
+        if a.get("trigger") == "use"
+        and a.get("item") == "sword"
+        and a.get("target_item") == "gem"
+    )
+    assert outputs[-2:] == [success_msg, "The gem is green."]
+
+
+def test_use_item_in_room(data_dir, monkeypatch):
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    assert g.world.move("Room 2")
     assert g.world.take("Gem")
+    assert g.world.move("Room 3")
+    assert g.world.take("Sword")
+    assert g.world.move("Room 2")
+    assert g.world.drop("Sword")
     g.cmd_use("Sword", "Gem")
     assert g.world.item_states["gem"] == "green"
     success_msg = next(


### PR DESCRIPTION
## Summary
- allow use command to find items in inventory or current room
- test using items from room and inventory combinations

## Testing
- `ruff check .`
- `pyright`
- `pytest --cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68b04cdc4c208330b211b02693b61077