### PR TITLE
Refactor generic command handling

### DIFF
--- a/tests/test_state_commands.py
+++ b/tests/test_state_commands.py
@@ -1,0 +1,14 @@
+import pytest
+from engine import game, io
+
+
+@pytest.mark.parametrize("command", ["destroy", "wear"])
+def test_state_command_requires_existing_state(data_dir, monkeypatch, command):
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    assert g.world.move("Room 3")
+    assert g.world.take("Sword")
+    getattr(g, f"cmd_{command}")("Sword")
+    assert outputs[-1] == g.messages["use_failure"]
+    assert "sword" in g.world.inventory


### PR DESCRIPTION
## Summary
- consolidate commands like destroy, wear, use, talk and show through shared helpers
- streamline command dispatch using command metadata
- add utility lookup for NPCs
- guard state-changing commands against unsupported item states
- cover destroy/wear commands with a regression test

## Testing
- `ruff .`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1741ae97c8330ae49d62553ab7594