### PR TITLE
Ensure Ashram deciphers map only after being asked

### DIFF
--- a/data/generic/world.yaml
+++ b/data/generic/world.yaml
@@ -51,7 +51,7 @@ actions:
     preconditions:
       npc_condition:
         - npc: ashram
-          state: met
+          state: helped
     effect:
       item_condition:
         - item: map_fragment

--- a/tests/test_exit_conditions.py
+++ b/tests/test_exit_conditions.py
@@ -23,6 +23,7 @@ def test_ruins_inaccessible_without_map(data_dir, monkeypatch):
     g.cmd_go("Ash Village")
     g.cmd_take("Map Fragment")
     g.cmd_go("Forest")
+    g.cmd_talk("Ashram")
     g.cmd_show("Map Fragment", "Ashram")
     g.cmd_go("Hut")
     g.cmd_go("Ruins")

--- a/tests/test_playthrough.py
+++ b/tests/test_playthrough.py
@@ -24,6 +24,7 @@ def test_game_reaches_ending(data_dir, monkeypatch):
         lambda: g.cmd_go("Ash Village"),
         lambda: g.cmd_take("Map Fragment"),
         lambda: g.cmd_go("Forest"),
+        lambda: g.cmd_talk("Ashram"),
         lambda: g.cmd_show("Map Fragment", "Ashram"),
         lambda: g.cmd_go("Hut"),
         lambda: g.cmd_go("Ruins"),


### PR DESCRIPTION
## Summary
- Require Ashram to be in "helped" state before deciphering the map
- Update playthrough and exit tests to speak with Ashram before showing the map

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b17fdebcd4833099eea4162b7f9596