### PR TITLE
Refactor engine into modular components

### DIFF
--- a/engine/commands.py
+++ b/engine/commands.py
@@ -1,0 +1,397 @@
+"""Command handling for the game."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Callable, cast
+
+from . import io, world
+from .language import LanguageManager
+from .persistence import SaveManager
+
+
+@dataclass
+class StateChange:
+    state: str
+    message_key: str
+
+
+STATE_COMMANDS: dict[str, StateChange] = {
+    "destroy": StateChange("destroyed", "destroyed"),
+    "wear": StateChange("worn", "worn"),
+}
+
+
+@dataclass
+class ActionConfig:
+    trigger: str
+    item_in_inventory: bool
+    target_is_npc: bool
+    item_missing_key: str
+    target_missing_key: str
+    failure_key: str
+
+
+ACTION_COMMANDS: dict[str, ActionConfig] = {
+    "use": ActionConfig(
+        trigger="use",
+        item_in_inventory=False,
+        target_is_npc=False,
+        item_missing_key="use_failure",
+        target_missing_key="use_failure",
+        failure_key="use_failure",
+    ),
+    "show": ActionConfig(
+        trigger="show",
+        item_in_inventory=True,
+        target_is_npc=True,
+        item_missing_key="not_carrying",
+        target_missing_key="no_npc",
+        failure_key="use_failure",
+    ),
+}
+
+
+class CommandProcessor:
+    """Parse and execute player commands."""
+
+    def __init__(
+        self,
+        world: world.World,
+        language: LanguageManager,
+        saver: SaveManager,
+        check_end: Callable[[], None],
+        check_npc_event: Callable[[], None],
+        stop: Callable[[], None],
+        update_world: Callable[[world.World], None],
+    ) -> None:
+        self.world = world
+        self.language_manager = language
+        self.save_manager = saver
+        self.check_end = check_end
+        self.check_npc_event = check_npc_event
+        self.stop = stop
+        self._update_world = update_world
+        self.command_info = language.command_info
+        self.command_keys = list(self.command_info.keys())
+        self.cmd_patterns: list[tuple[re.Pattern[str], str, str]] = []
+        self.reverse_cmds: dict[str, tuple[str, str]] = {}
+        self._build_cmd_patterns()
+
+    # ------------------------------------------------------------------
+    def execute(self, raw: str) -> None:
+        """Execute the command contained in ``raw``."""
+
+        for pattern, cmd_key, _ in self.cmd_patterns:
+            match = pattern.fullmatch(raw)
+            if not match:
+                continue
+            groups = match.groupdict()
+            handler = getattr(self, f"cmd_{cmd_key}", self.cmd_unknown)
+            info = self.command_info.get(cmd_key, {})
+            if info.get("arguments") == 2:
+                a = groups.get("a", "").strip()
+                b = groups.get("b", "").strip()
+                two_handler = cast(Callable[[str, str], None], handler)
+                two_handler(a, b)
+            else:
+                arg = groups.get("a", "") or groups.get("b", "") or ""
+                one_handler = cast(Callable[[str], None], handler)
+                one_handler(arg.strip())
+            break
+        else:
+            self.cmd_unknown(raw)
+
+    # ------------------------------------------------------------------
+    def _build_cmd_patterns(self) -> None:
+        self.cmd_patterns.clear()
+        self.reverse_cmds.clear()
+        for key in self.command_keys:
+            val = self.language_manager.commands.get(key, [])
+            entries = val if isinstance(val, list) else [val]
+            for entry in entries:
+                pattern, base = self._compile_command(entry)
+                self.cmd_patterns.append((pattern, key, entry))
+                if base not in self.reverse_cmds:
+                    self.reverse_cmds[base] = (key, entry)
+        self.cmd_patterns.sort(key=lambda x: len(x[0].pattern), reverse=True)
+        self.reverse_cmds["language"] = ("language", "language")
+
+    def _compile_command(self, pattern: str) -> tuple[re.Pattern[str], str]:
+        tokens = pattern.split()
+        placeholder_positions = [i for i, t in enumerate(tokens) if t in ("$a", "$b")]
+        last_placeholder = placeholder_positions[-1] if placeholder_positions else -1
+        base = None
+        parts: list[str] = []
+        for idx, token in enumerate(tokens):
+            if token == "$a":
+                part = r"(?P<a>.+)" if idx == last_placeholder else r"(?P<a>.+?)"
+            elif token == "$b":
+                part = r"(?P<b>.+)" if idx == last_placeholder else r"(?P<b>.+?)"
+            else:
+                if base is None:
+                    base = token
+                part = re.escape(token)
+            parts.append(part)
+        regex = r"^" + r"\s+".join(parts) + r"$"
+        return re.compile(regex), base or pattern
+
+    # ------------------------------------------------------------------
+    def _strip_suffix(self, arg: str, suffix: str) -> str:
+        if suffix and arg.endswith(f" {suffix}"):
+            return arg[: -len(suffix) - 1].strip()
+        return arg
+
+    def _find_item_id(self, name: str, *, in_inventory: bool = False) -> str | None:
+        if not name:
+            return None
+        name_cf = name.casefold()
+        if not in_inventory:
+            room = self.world.rooms[self.world.current]
+            for item_id in room.get("items", []):
+                names = self.world.items.get(item_id, {}).get("names", [])
+                if any(n.casefold() == name_cf for n in names):
+                    return item_id
+        for item_id in self.world.inventory:
+            names = self.world.items.get(item_id, {}).get("names", [])
+            if any(n.casefold() == name_cf for n in names):
+                return item_id
+        return None
+
+    def _find_npc_id(self, name: str) -> str | None:
+        if not name:
+            return None
+        name_cf = name.casefold()
+        for npc_id, npc in self.world.npcs.items():
+            names = npc.get("names", [])
+            if not any(n.casefold() == name_cf for n in names):
+                continue
+            if npc.get("meet", {}).get("location") != self.world.current:
+                return None
+            return npc_id
+        return None
+
+    def _state_command(self, cmd: str, item_name: str) -> None:
+        if not item_name:
+            self.cmd_unknown(item_name)
+            return
+        cfg = STATE_COMMANDS[cmd]
+        item_id = self._find_item_id(item_name, in_inventory=True)
+        if not item_id:
+            io.output(self.language_manager.messages["not_carrying"])
+            self.check_end()
+            return
+        if not self.world.set_item_state(item_id, cfg.state):
+            io.output(self.language_manager.messages["use_failure"])
+            self.check_end()
+            return
+        self.world.inventory.remove(item_id)
+        self.world.debug(f"inventory {self.world.inventory}")
+        io.output(self.language_manager.messages[cfg.message_key].format(item=item_name))
+        self.check_end()
+
+    def _action_command(
+        self, cmd: str, item_name: str, target_name: str
+    ) -> None:
+        cfg = ACTION_COMMANDS[cmd]
+        if not item_name or not target_name:
+            self.cmd_unknown(cmd)
+            return
+        item_id = self._find_item_id(item_name, in_inventory=cfg.item_in_inventory)
+        if not item_id:
+            io.output(self.language_manager.messages[cfg.item_missing_key])
+            self.check_end()
+            return
+        finder = self._find_npc_id if cfg.target_is_npc else self._find_item_id
+        target_id = finder(target_name)
+        if not target_id:
+            io.output(self.language_manager.messages[cfg.target_missing_key])
+            self.check_end()
+            return
+        if self._execute_action(cfg.trigger, item_id, target_id):
+            self.check_end()
+            return
+        io.output(self.language_manager.messages[cfg.failure_key])
+        self.check_end()
+
+    def _execute_action(
+        self, trigger: str, item_id: str, target_id: str | None = None
+    ) -> bool:
+        for action in self.world.actions:
+            if action.get("trigger") != trigger:
+                continue
+            if action.get("item") and action.get("item") != item_id:
+                continue
+            if action.get("target_item") and action.get("target_item") != target_id:
+                continue
+            if action.get("target_npc") and action.get("target_npc") != target_id:
+                continue
+            if not self.world.check_preconditions(action.get("preconditions")):
+                continue
+            effect = action.get("effect", {})
+            self.world.apply_effect(effect)
+            message = action.get("messages", {}).get("success")
+            if message:
+                io.output(message)
+            return True
+        return False
+
+    def describe_item(self, item_name: str) -> None:
+        if not item_name:
+            self.cmd_unknown(item_name)
+            return
+        item_id = self._find_item_id(item_name)
+        if not item_id:
+            io.output(self.language_manager.messages["item_not_present"])
+            return
+        desc = self.world.describe_item(item_name)
+        if desc:
+            io.output(desc)
+        self._execute_action("examine", item_id)
+        self.check_end()
+
+    # ------------------------------------------------------------------
+    # Command handlers
+    def cmd_quit(self, arg: str) -> None:  # noqa: ARG002 - required signature
+        self.save_manager.save(self.world, self.language_manager.language)
+        io.output(self.language_manager.messages["farewell"])
+        self.stop()
+
+    def cmd_inventory(self, arg: str) -> None:  # noqa: ARG002
+        io.output(self.world.describe_inventory(self.language_manager.messages))
+
+    def cmd_take(self, arg: str) -> None:
+        if not arg:
+            self.cmd_unknown(arg)
+            return
+        item_name = arg
+        taken = self.world.take(item_name)
+        if taken:
+            io.output(self.language_manager.messages["taken"].format(item=taken))
+        else:
+            io.output(self.language_manager.messages["item_not_present"])
+        self.check_end()
+
+    def cmd_drop(self, arg: str) -> None:
+        if not arg:
+            self.cmd_unknown(arg)
+            return
+        item = arg
+        if self.world.drop(item):
+            io.output(self.language_manager.messages["dropped"].format(item=item))
+        else:
+            io.output(self.language_manager.messages["not_carrying"])
+        self.check_end()
+
+    def cmd_destroy(self, arg: str) -> None:
+        self._state_command("destroy", arg)
+
+    def cmd_wear(self, arg: str) -> None:
+        self._state_command("wear", arg)
+
+    def cmd_look(self, arg: str) -> None:
+        if arg:
+            self.cmd_unknown(arg)
+            return
+        io.output(self.world.describe_current(self.language_manager.messages))
+
+    def cmd_examine(self, arg: str) -> None:
+        self.describe_item(arg)
+
+    def cmd_go(self, arg: str) -> None:
+        if not arg:
+            self.cmd_unknown(arg)
+            return
+        direction = arg
+        if self.world.can_move(direction) and self.world.move(direction):
+            io.output(self.world.describe_current(self.language_manager.messages))
+            self.check_npc_event()
+        else:
+            io.output(self.language_manager.messages["cannot_move"])
+        self.check_end()
+
+    def cmd_help(self, arg: str) -> None:
+        if not arg:
+            names: list[str] = []
+            for key in self.command_keys:
+                val = self.language_manager.commands.get(key, [])
+                entries = val if isinstance(val, list) else [val]
+                first = entries[0]
+                names.append(first.split()[0])
+            io.output(
+                self.language_manager.messages["help"].format(commands=", ".join(names))
+            )
+            return
+        cmd_info = self.reverse_cmds.get(arg)
+        if not cmd_info:
+            self.cmd_unknown(arg)
+            return
+        key, _ = cmd_info
+        entries = self.language_manager.commands.get(key, [])
+        entries = entries if isinstance(entries, list) else [entries]
+        usages: list[str] = []
+        for entry in entries:
+            if self.language_manager.command_info.get(key, {}).get(
+                "optional_arguments"
+            ) and "$" not in entry:
+                continue
+            usage = entry.replace("$a", "<>").replace("$b", "<>")
+            usages.append(usage)
+        header = self.language_manager.messages.get(
+            "help_usage", "Usage of \"{command}\" and synonyms:"
+        )
+        io.output(header.format(command=key) + "\n" + "\n".join(usages))
+
+    def cmd_language(self, arg: str) -> None:
+        if not arg:
+            self.cmd_unknown(arg)
+            return
+        language = arg.strip()
+        try:
+            new_world = self.language_manager.switch(language, self.world, self.save_manager)
+        except ValueError:
+            io.output(
+                self.language_manager.messages.get(
+                    "language_unknown", "Unknown language"
+                )
+            )
+            return
+        self.world = new_world
+        self._update_world(new_world)
+        self._build_cmd_patterns()
+        io.output(
+            self.language_manager.messages["language_set"].format(language=language)
+        )
+
+    def cmd_show(self, item_name: str, npc_name: str) -> None:
+        self._action_command("show", item_name, npc_name)
+
+    def cmd_talk(self, arg: str) -> None:
+        if not arg:
+            self.cmd_unknown(arg)
+            return
+        npc_id = self._find_npc_id(arg)
+        if not npc_id:
+            io.output(self.language_manager.messages["no_npc"])
+            return
+        npc = self.world.npcs[npc_id]
+        state = self.world.npc_state(npc_id)
+        talk_cfg = npc.get("states", {}).get(state, {})
+        text = talk_cfg.get("talk")
+        if text:
+            io.output(text)
+        else:
+            io.output(self.language_manager.messages["no_npc"])
+        if state != "helped":
+            self.world.set_npc_state(npc_id, "helped")
+
+    def cmd_use(self, item_name: str, target_name: str) -> None:
+        self._action_command("use", item_name, target_name)
+
+    def cmd_unknown(self, arg: str) -> None:  # noqa: ARG002 - compatibility
+        io.output(self.language_manager.messages["unknown_command"])
+
+
+__all__ = ["CommandProcessor"]
+

--- a/engine/game.py
+++ b/engine/game.py
@@ -1,74 +1,30 @@
-"""Core game loop."""
+"""Core game loop orchestrator."""
+
+from __future__ import annotations
 
 from pathlib import Path
-import re
-from dataclasses import dataclass
-from typing import Callable, cast
 
-import yaml
+from engine import io, parser, world, llm, integrity
 
-from engine import io, parser, world, llm, i18n, integrity
-
-
-@dataclass
-class StateChange:
-    state: str
-    message_key: str
-
-
-STATE_COMMANDS: dict[str, StateChange] = {
-    "destroy": StateChange("destroyed", "destroyed"),
-    "wear": StateChange("worn", "worn"),
-}
-
-
-@dataclass
-class ActionConfig:
-    trigger: str
-    item_in_inventory: bool
-    target_is_npc: bool
-    item_missing_key: str
-    target_missing_key: str
-    failure_key: str
-
-
-ACTION_COMMANDS: dict[str, ActionConfig] = {
-    "use": ActionConfig(
-        trigger="use",
-        item_in_inventory=False,
-        target_is_npc=False,
-        item_missing_key="use_failure",
-        target_missing_key="use_failure",
-        failure_key="use_failure",
-    ),
-    "show": ActionConfig(
-        trigger="show",
-        item_in_inventory=True,
-        target_is_npc=True,
-        item_missing_key="not_carrying",
-        target_missing_key="no_npc",
-        failure_key="use_failure",
-    ),
-}
+from .commands import CommandProcessor
+from .language import LanguageManager
+from .persistence import SaveManager
 
 
 class Game:
     def __init__(self, world_data_path: str, language: str, debug: bool = False) -> None:
         data_path = Path(world_data_path)
         self.data_dir = data_path.parent.parent
-        self.save_path = self.data_dir / "save.yaml"
-        generic_path = self.data_dir / "generic" / "world.yaml"
         self.debug = debug
+        self.save_manager = SaveManager(self.data_dir)
 
-        save_data: dict[str, object] = {}
-        if self.save_path.exists():
-            with open(self.save_path, encoding="utf-8") as fh:
-                save_data = yaml.safe_load(fh) or {}
-        self.language = str(save_data.get("language", language))
+        save_data = self.save_manager.load()
         self._show_intro = not save_data
-        lang_world_path = self.data_dir / self.language / "world.yaml"
+        self._language = str(save_data.get("language", language))
+        generic_path = self.data_dir / "generic" / "world.yaml"
+        lang_world_path = self.data_dir / self._language / "world.yaml"
 
-        warnings = integrity.check_translations(self.language, self.data_dir)
+        warnings = integrity.check_translations(self._language, self.data_dir)
         for msg in warnings:
             io.output(f"WARNING: {msg}")
 
@@ -84,342 +40,32 @@ class Game:
             raise SystemExit("Integrity check failed")
 
         if save_data:
-            self.world.load_state(self.save_path)
-            self.save_path.unlink()
+            self.world.load_state(self.save_manager.save_path)
+            self.save_manager.cleanup()
 
-        self.messages = i18n.load_messages(self.language)
-        self.commands = i18n.load_commands(self.language)
-        self.command_info = i18n.load_command_info()
-        self.command_keys = list(self.command_info.keys())
-        self.cmd_patterns: list[tuple[re.Pattern[str], str, str]] = []
-        self.reverse_cmds: dict[str, tuple[str, str]] = {}
-        self._build_cmd_patterns()
+        self.language_manager = LanguageManager(
+            self.data_dir, self._language, debug=debug
+        )
+        self.command_processor = CommandProcessor(
+            self.world,
+            self.language_manager,
+            self.save_manager,
+            self._check_end,
+            self._check_npc_event,
+            self.stop,
+            self._update_world,
+        )
         self.running = True
 
-    def run(self) -> None:
-        if self._show_intro and self.world.intro:
-            io.output(self.world.intro)
-        io.output(self.world.describe_current(self.messages))
-        self._check_npc_event()
-        self._check_end()
-        try:
-            while self.running:
-                raw = io.get_input()
-                raw = llm.interpret(raw)
-                raw = parser.parse(raw)
-                for pattern, cmd_key, _ in self.cmd_patterns:
-                    match = pattern.fullmatch(raw)
-                    if not match:
-                        continue
-                    groups = match.groupdict()
-                    handler = getattr(self, f"cmd_{cmd_key}", self.cmd_unknown)
-                    info = self.command_info.get(cmd_key, {})
-                    if info.get("arguments") == 2:
-                        a = groups.get("a", "").strip()
-                        b = groups.get("b", "").strip()
-                        two_handler = cast(Callable[[str, str], None], handler)
-                        two_handler(a, b)
-                    else:
-                        arg = groups.get("a", "") or groups.get("b", "") or ""
-                        one_handler = cast(Callable[[str], None], handler)
-                        one_handler(arg.strip())
-                    break
-                else:
-                    self.cmd_unknown(raw)
-        except (EOFError, KeyboardInterrupt):
-            io.output(self.messages["farewell"])
-        finally:
-            self._save_state()
+    @property
+    def language(self) -> str:
+        return self.language_manager.language
 
-    def _save_state(self) -> None:
-        data = self.world.to_state()
-        data["language"] = self.language
-        with open(self.save_path, "w", encoding="utf-8") as fh:
-            yaml.safe_dump(data, fh)
-
-    def _strip_suffix(self, arg: str, suffix: str) -> str:
-        if suffix and arg.endswith(f" {suffix}"):
-            return arg[: -len(suffix) - 1].strip()
-        return arg
-
-    def _find_item_id(self, name: str, *, in_inventory: bool = False) -> str | None:
-        if not name:
-            return None
-        name_cf = name.casefold()
-        if not in_inventory:
-            room = self.world.rooms[self.world.current]
-            for item_id in room.get("items", []):
-                names = self.world.items.get(item_id, {}).get("names", [])
-                if any(n.casefold() == name_cf for n in names):
-                    return item_id
-        for item_id in self.world.inventory:
-            names = self.world.items.get(item_id, {}).get("names", [])
-            if any(n.casefold() == name_cf for n in names):
-                return item_id
-        return None
-
-    def _find_npc_id(self, name: str) -> str | None:
-        if not name:
-            return None
-        name_cf = name.casefold()
-        for npc_id, npc in self.world.npcs.items():
-            names = npc.get("names", [])
-            if not any(n.casefold() == name_cf for n in names):
-                continue
-            if npc.get("meet", {}).get("location") != self.world.current:
-                return None
-            return npc_id
-        return None
-
-    def _state_command(self, cmd: str, item_name: str) -> None:
-        if not item_name:
-            self.cmd_unknown(item_name)
-            return
-        cfg = STATE_COMMANDS[cmd]
-        item_id = self._find_item_id(item_name, in_inventory=True)
-        if not item_id:
-            io.output(self.messages["not_carrying"])
-            self._check_end()
-            return
-        if not self.world.set_item_state(item_id, cfg.state):
-            io.output(self.messages["use_failure"])
-            self._check_end()
-            return
-        self.world.inventory.remove(item_id)
-        self.world.debug(f"inventory {self.world.inventory}")
-        io.output(self.messages[cfg.message_key].format(item=item_name))
-        self._check_end()
-
-    def _action_command(
-        self, cmd: str, item_name: str, target_name: str
-    ) -> None:
-        cfg = ACTION_COMMANDS[cmd]
-        if not item_name or not target_name:
-            self.cmd_unknown(cmd)
-            return
-        item_id = self._find_item_id(item_name, in_inventory=cfg.item_in_inventory)
-        if not item_id:
-            io.output(self.messages[cfg.item_missing_key])
-            self._check_end()
-            return
-        finder = self._find_npc_id if cfg.target_is_npc else self._find_item_id
-        target_id = finder(target_name)
-        if not target_id:
-            io.output(self.messages[cfg.target_missing_key])
-            self._check_end()
-            return
-        if self._execute_action(cfg.trigger, item_id, target_id):
-            self._check_end()
-            return
-        io.output(self.messages[cfg.failure_key])
-        self._check_end()
-
-    def _execute_action(
-        self, trigger: str, item_id: str, target_id: str | None = None
-    ) -> bool:
-        for action in self.world.actions:
-            if action.get("trigger") != trigger:
-                continue
-            if action.get("item") and action.get("item") != item_id:
-                continue
-            if action.get("target_item") and action.get("target_item") != target_id:
-                continue
-            if action.get("target_npc") and action.get("target_npc") != target_id:
-                continue
-            if not self.world.check_preconditions(action.get("preconditions")):
-                continue
-            effect = action.get("effect", {})
-            self.world.apply_effect(effect)
-            message = action.get("messages", {}).get("success")
-            if message:
-                io.output(message)
-            return True
-        return False
-
-    def describe_item(self, item_name: str) -> None:
-        if not item_name:
-            self.cmd_unknown(item_name)
-            return
-        item_id = self._find_item_id(item_name)
-        if not item_id:
-            io.output(self.messages["item_not_present"])
-            return
-        desc = self.world.describe_item(item_name)
-        if desc:
-            io.output(desc)
-        self._execute_action("examine", item_id)
-        self._check_end()
-
-    def cmd_quit(self, arg: str) -> None:
-        self._save_state()
-        io.output(self.messages["farewell"])
-        self.running = False
-
-    def cmd_inventory(self, arg: str) -> None:
-        io.output(self.world.describe_inventory(self.messages))
-
-    def cmd_take(self, arg: str) -> None:
-        if not arg:
-            self.cmd_unknown(arg)
-            return
-        item_name = arg
-        taken = self.world.take(item_name)
-        if taken:
-            io.output(self.messages["taken"].format(item=taken))
-        else:
-            io.output(self.messages["item_not_present"])
-        self._check_end()
-
-    def cmd_drop(self, arg: str) -> None:
-        if not arg:
-            self.cmd_unknown(arg)
-            return
-        item = arg
-        if self.world.drop(item):
-            io.output(self.messages["dropped"].format(item=item))
-        else:
-            io.output(self.messages["not_carrying"])
-        self._check_end()
-
-    def cmd_destroy(self, arg: str) -> None:
-        self._state_command("destroy", arg)
-
-    def cmd_wear(self, arg: str) -> None:
-        self._state_command("wear", arg)
-
-    def cmd_look(self, arg: str) -> None:
-        if arg:
-            self.cmd_unknown(arg)
-            return
-        io.output(self.world.describe_current(self.messages))
-
-    def cmd_examine(self, arg: str) -> None:
-        self.describe_item(arg)
-
-    def cmd_go(self, arg: str) -> None:
-        if not arg:
-            self.cmd_unknown(arg)
-            return
-        direction = arg
-        if self.world.can_move(direction) and self.world.move(direction):
-            io.output(self.world.describe_current(self.messages))
-            self._check_npc_event()
-        else:
-            io.output(self.messages["cannot_move"])
-        self._check_end()
-
-    def cmd_help(self, arg: str) -> None:
-        if not arg:
-            names: list[str] = []
-            for key in self.command_keys:
-                val = self.commands.get(key, [])
-                entries = val if isinstance(val, list) else [val]
-                first = entries[0]
-                names.append(first.split()[0])
-            io.output(self.messages["help"].format(commands=", ".join(names)))
-            return
-        cmd_info = self.reverse_cmds.get(arg)
-        if not cmd_info:
-            self.cmd_unknown(arg)
-            return
-        key, _ = cmd_info
-        entries = self.commands.get(key, [])
-        entries = entries if isinstance(entries, list) else [entries]
-        usages: list[str] = []
-        for entry in entries:
-            if self.command_info.get(key, {}).get("optional_arguments") and "$" not in entry:
-                continue
-            usage = entry.replace("$a", "<>").replace("$b", "<>")
-            usages.append(usage)
-        header = self.messages.get("help_usage", "Usage of \"{command}\" and synonyms:")
-        io.output(header.format(command=key) + "\n" + "\n".join(usages))
-
-    def cmd_language(self, arg: str) -> None:
-        if not arg:
-            self.cmd_unknown(arg)
-            return
-        language = arg.strip()
-        try:
-            messages = i18n.load_messages(language)
-            commands = i18n.load_commands(language)
-            world_path = self.data_dir / language / "world.yaml"
-            generic_path = self.data_dir / "generic" / "world.yaml"
-            new_world = world.World.from_files(
-                generic_path, world_path, debug=self.debug
-            )
-        except FileNotFoundError:
-            io.output(self.messages.get("language_unknown", "Unknown language"))
-            return
-        self._save_state()
-        new_world.load_state(self.save_path)
-        self.save_path.unlink()
+    def _update_world(self, new_world: world.World) -> None:
         self.world = new_world
-        self.language = language
-        self.messages = messages
-        self.commands = commands
-        self.cmd_patterns = []
-        self.reverse_cmds = {}
-        self._build_cmd_patterns()
-        io.output(self.messages["language_set"].format(language=language))
 
-    def cmd_show(self, item_name: str, npc_name: str) -> None:
-        self._action_command("show", item_name, npc_name)
-
-    def cmd_talk(self, arg: str) -> None:
-        if not arg:
-            self.cmd_unknown(arg)
-            return
-        npc_id = self._find_npc_id(arg)
-        if not npc_id:
-            io.output(self.messages["no_npc"])
-            return
-        npc = self.world.npcs[npc_id]
-        state = self.world.npc_state(npc_id)
-        talk_cfg = npc.get("states", {}).get(state, {})
-        text = talk_cfg.get("talk")
-        if text:
-            io.output(text)
-        else:
-            io.output(self.messages["no_npc"])
-        if state != "helped":
-            self.world.set_npc_state(npc_id, "helped")
-
-    def cmd_use(self, item_name: str, target_name: str) -> None:
-        self._action_command("use", item_name, target_name)
-
-    def _build_cmd_patterns(self) -> None:
-        for key in self.command_keys:
-            val = self.commands.get(key, [])
-            entries = val if isinstance(val, list) else [val]
-            for entry in entries:
-                pattern, base = self._compile_command(entry)
-                self.cmd_patterns.append((pattern, key, entry))
-                if base not in self.reverse_cmds:
-                    self.reverse_cmds[base] = (key, entry)
-        self.cmd_patterns.sort(key=lambda x: len(x[0].pattern), reverse=True)
-        self.reverse_cmds["language"] = ("language", "language")
-
-    def _compile_command(self, pattern: str) -> tuple[re.Pattern[str], str]:
-        tokens = pattern.split()
-        placeholder_positions = [i for i, t in enumerate(tokens) if t in ("$a", "$b")]
-        last_placeholder = placeholder_positions[-1] if placeholder_positions else -1
-        base = None
-        parts: list[str] = []
-        for idx, token in enumerate(tokens):
-            if token == "$a":
-                part = r"(?P<a>.+)" if idx == last_placeholder else r"(?P<a>.+?)"
-            elif token == "$b":
-                part = r"(?P<b>.+)" if idx == last_placeholder else r"(?P<b>.+?)"
-            else:
-                if base is None:
-                    base = token
-                part = re.escape(token)
-            parts.append(part)
-        regex = r"^" + r"\s+".join(parts) + r"$"
-        return re.compile(regex), base or pattern
-
-    def cmd_unknown(self, arg: str) -> None:
-        io.output(self.messages["unknown_command"])
+    def stop(self) -> None:
+        self.running = False
 
     def _check_end(self) -> None:
         ending = self.world.check_endings()
@@ -440,6 +86,24 @@ class Game:
                     io.output(text)
                 self.world.meet_npc(npc_id)
 
+    def run(self) -> None:
+        if self._show_intro and self.world.intro:
+            io.output(self.world.intro)
+        io.output(self.world.describe_current(self.language_manager.messages))
+        self._check_npc_event()
+        self._check_end()
+        try:
+            while self.running:
+                raw = io.get_input()
+                raw = llm.interpret(raw)
+                raw = parser.parse(raw)
+                self.command_processor.execute(raw)
+        except (EOFError, KeyboardInterrupt):
+            io.output(self.language_manager.messages["farewell"])
+        finally:
+            self.save_manager.save(self.world, self.language_manager.language)
+
 
 def run(world_data_path: str, language: str = "en", debug: bool = False) -> None:
     Game(world_data_path, language, debug=debug).run()
+

--- a/engine/language.py
+++ b/engine/language.py
@@ -1,0 +1,49 @@
+"""Handle translations and language switching."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from . import i18n, world
+from .persistence import SaveManager
+
+
+class LanguageManager:
+    """Manage messages, command translations and language switches."""
+
+    def __init__(self, data_dir: Path, language: str, debug: bool = False):
+        self.data_dir = data_dir
+        self.debug = debug
+        self.language = language
+        self.messages = i18n.load_messages(language)
+        self.commands = i18n.load_commands(language)
+        self.command_info = i18n.load_command_info()
+
+    def switch(self, language: str, current_world: world.World, save_manager: SaveManager) -> world.World:
+        """Switch the game to a different language.
+
+        Returns the reloaded world instance.  Raises ``ValueError`` if the
+        language data cannot be found.
+        """
+
+        try:
+            messages = i18n.load_messages(language)
+            commands = i18n.load_commands(language)
+            generic_path = self.data_dir / "generic" / "world.yaml"
+            world_path = self.data_dir / language / "world.yaml"
+            new_world = world.World.from_files(generic_path, world_path, debug=self.debug)
+        except FileNotFoundError as exc:  # pragma: no cover - defensive programming
+            raise ValueError("Unknown language") from exc
+
+        save_manager.save(current_world, self.language)
+        new_world.load_state(save_manager.save_path)
+        save_manager.cleanup()
+
+        self.language = language
+        self.messages = messages
+        self.commands = commands
+        return new_world
+
+
+__all__ = ["LanguageManager"]
+

--- a/engine/persistence.py
+++ b/engine/persistence.py
@@ -1,0 +1,51 @@
+"""Save game state to disk."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Any, TYPE_CHECKING
+
+import yaml
+
+if TYPE_CHECKING:  # pragma: no cover - used for type checking only
+    from .world import World
+
+
+class SaveManager:
+    """Handle persisting the game state.
+
+    Parameters
+    ----------
+    data_dir:
+        Directory where the ``save.yaml`` file is stored.
+    """
+
+    def __init__(self, data_dir: Path):
+        self.data_dir = data_dir
+        self.save_path = self.data_dir / "save.yaml"
+
+    def load(self) -> Dict[str, Any]:
+        """Return previously saved data if available."""
+
+        if not self.save_path.exists():
+            return {}
+        with open(self.save_path, encoding="utf-8") as fh:
+            return yaml.safe_load(fh) or {}
+
+    def save(self, world: "World", language: str) -> None:
+        """Persist the current world state and language."""
+
+        data = world.to_state()
+        data["language"] = language
+        with open(self.save_path, "w", encoding="utf-8") as fh:
+            yaml.safe_dump(data, fh)
+
+    def cleanup(self) -> None:
+        """Remove the save file if it exists."""
+
+        if self.save_path.exists():
+            self.save_path.unlink()
+
+
+__all__ = ["SaveManager"]
+

--- a/tests/test_debug_mode.py
+++ b/tests/test_debug_mode.py
@@ -4,12 +4,12 @@ from engine import game
 def test_debug_outputs_after_state_changes(data_dir, capsys):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en", debug=True)
     capsys.readouterr()
-    g.cmd_go("Room 2")
+    g.command_processor.cmd_go("Room 2")
     err = capsys.readouterr().err
     assert "-- location room2" in err
     assert "-- npc old_man state met" in err
 
-    g.cmd_take("Gem")
+    g.command_processor.cmd_take("Gem")
     err = capsys.readouterr().err
     assert "-- inventory ['gem']" in err
     assert "-- room room2 items []" in err

--- a/tests/test_endings.py
+++ b/tests/test_endings.py
@@ -34,8 +34,8 @@ def test_end_condition_inventory_and_location(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_take("Crown")
-    g.cmd_go("Room2")
+    g.command_processor.cmd_take("Crown")
+    g.command_processor.cmd_go("Room2")
     assert outputs[-1] == "You win!"
 
 
@@ -71,7 +71,7 @@ def test_end_condition_inventory_lacks(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_go("Room2")
+    g.command_processor.cmd_go("Room2")
     assert outputs[-1] == "No crown, no victory."
 
 
@@ -107,7 +107,7 @@ def test_end_condition_or_room_has(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_go("Room2")
+    g.command_processor.cmd_go("Room2")
     assert outputs[-1] == "You see the sword and know your quest is over."
 
 

--- a/tests/test_examine_action.py
+++ b/tests/test_examine_action.py
@@ -20,7 +20,7 @@ def test_examine_triggers_action(data_dir, monkeypatch):
         }
     )
 
-    g.describe_item("Stone")
+    g.command_processor.describe_item("Stone")
 
     assert outputs[-2:] == ["A stone.", "You find a coin."]
     assert "coin" in g.world.rooms[g.world.current].get("items", [])

--- a/tests/test_exit_conditions.py
+++ b/tests/test_exit_conditions.py
@@ -13,20 +13,20 @@ def test_ruins_inaccessible_without_map(data_dir, monkeypatch):
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
 
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_go("Forest")
+    g.command_processor.cmd_go("Forest")
     assert g.world.current == "forest"
 
-    g.cmd_go("Ruins")
+    g.command_processor.cmd_go("Ruins")
     assert g.world.current == "forest"
-    assert outputs[-1] == g.messages["cannot_move"]
+    assert outputs[-1] == g.language_manager.messages["cannot_move"]
 
-    g.cmd_go("Ash Village")
-    g.cmd_talk("Villager")
-    g.cmd_take("Map Fragment")
-    g.cmd_go("Forest")
-    g.cmd_talk("Ashram")
-    g.cmd_show("Map Fragment", "Ashram")
-    g.cmd_go("Hut")
-    g.cmd_go("Ruins")
+    g.command_processor.cmd_go("Ash Village")
+    g.command_processor.cmd_talk("Villager")
+    g.command_processor.cmd_take("Map Fragment")
+    g.command_processor.cmd_go("Forest")
+    g.command_processor.cmd_talk("Ashram")
+    g.command_processor.cmd_show("Map Fragment", "Ashram")
+    g.command_processor.cmd_go("Hut")
+    g.command_processor.cmd_go("Ruins")
     assert g.world.current == "ruins"
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -5,14 +5,14 @@ def test_help_lists_commands(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_help("")
+    g.command_processor.cmd_help("")
     names = []
-    for key in g.command_keys:
-        val = g.commands.get(key, [])
+    for key in g.command_processor.command_keys:
+        val = g.language_manager.commands.get(key, [])
         entries = val if isinstance(val, list) else [val]
         first = entries[0]
         names.append(first.split()[0])
-    expected = g.messages["help"].format(commands=", ".join(names))
+    expected = g.language_manager.messages["help"].format(commands=", ".join(names))
     assert outputs[-1] == expected
 
 
@@ -20,11 +20,11 @@ def test_help_lists_synonyms(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_help("destroy")
-    entries = g.commands["destroy"]
+    g.command_processor.cmd_help("destroy")
+    entries = g.language_manager.commands["destroy"]
     usages = [e.replace("$a", "<>").replace("$b", "<>") for e in entries]
     expected = (
-        g.messages["help_usage"].format(command="destroy")
+        g.language_manager.messages["help_usage"].format(command="destroy")
         + "\n"
         + "\n".join(usages)
     )
@@ -35,9 +35,9 @@ def test_help_optional_argument(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_help("help")
+    g.command_processor.cmd_help("help")
     expected = (
-        g.messages["help_usage"].format(command="help")
+        g.language_manager.messages["help_usage"].format(command="help")
         + "\nhelp <>\nh <>"
     )
     assert outputs[-1] == expected

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -5,15 +5,18 @@ def test_language_switch(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_language("de")
-    assert g.messages["farewell"] == "Auf Wiedersehen!"
-    assert g.commands["look"][0] == "umschau"
-    assert g.commands["examine"][0] == "ansehen $a"
-    assert g.commands["talk"][0] == "rede mit $a"
-    assert g.reverse_cmds["hilfe"][0] == "help"
-    assert g.reverse_cmds["language"][0] == "language"
-    assert g.reverse_cmds["sprache"][0] == "language"
-    assert outputs[-1] == g.messages["language_set"].format(language="de")
+    g.command_processor.cmd_language("de")
+    assert g.language_manager.messages["farewell"] == "Auf Wiedersehen!"
+    assert g.language_manager.commands["look"][0] == "umschau"
+    assert g.language_manager.commands["examine"][0] == "ansehen $a"
+    assert g.language_manager.commands["talk"][0] == "rede mit $a"
+    assert g.command_processor.reverse_cmds["hilfe"][0] == "help"
+    assert g.command_processor.reverse_cmds["language"][0] == "language"
+    assert g.command_processor.reverse_cmds["sprache"][0] == "language"
+    assert (
+        outputs[-1]
+        == g.language_manager.messages["language_set"].format(language="de")
+    )
     assert g.world.items["sword"]["names"][0] == "Schwert"
 
 
@@ -21,12 +24,12 @@ def test_language_persistence(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_language("de")
-    g.cmd_quit("")
+    g.command_processor.cmd_language("de")
+    g.command_processor.cmd_quit("")
     g2 = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g2.language == "de"
-    assert g2.messages["farewell"] == "Auf Wiedersehen!"
-    assert g2.reverse_cmds["language"][0] == "language"
+    assert g2.language_manager.messages["farewell"] == "Auf Wiedersehen!"
+    assert g2.command_processor.reverse_cmds["language"][0] == "language"
     assert g2.world.items["sword"]["names"][0] == "Schwert"
 
 
@@ -34,7 +37,10 @@ def test_language_command_base_word(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "de" / "world.yaml"), "de")
-    cmd, _ = g.reverse_cmds["language"]
-    getattr(g, f"cmd_{cmd}")("en")
+    cmd, _ = g.command_processor.reverse_cmds["language"]
+    getattr(g.command_processor, f"cmd_{cmd}")("en")
     assert g.language == "en"
-    assert outputs[-1] == g.messages["language_set"].format(language="en")
+    assert (
+        outputs[-1]
+        == g.language_manager.messages["language_set"].format(language="en")
+    )

--- a/tests/test_look_exits.py
+++ b/tests/test_look_exits.py
@@ -5,7 +5,7 @@ def test_room_description_lists_exits(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_look("")
+    g.command_processor.cmd_look("")
     assert outputs[-1] == "Room 1. Exits: Room 2, Room 3."
 
 
@@ -14,7 +14,7 @@ def test_room_description_lists_items_npcs_and_exits(data_dir, monkeypatch):
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
-    g.cmd_look("")
+    g.command_processor.cmd_look("")
     assert (
         outputs[-1]
         == "Room 2. You see here: Gem. You see here: Old Man. Exits: Room 1, Room 3."

--- a/tests/test_look_item.py
+++ b/tests/test_look_item.py
@@ -6,7 +6,7 @@ def test_look_item_describes(data_dir, monkeypatch):
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
-    g.cmd_examine("gem")
+    g.command_processor.cmd_examine("gem")
     assert outputs[-1] == "A red gem."
 
 
@@ -15,5 +15,5 @@ def test_look_item_not_present(data_dir, monkeypatch):
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
-    g.cmd_examine("sword")
-    assert outputs[-1] == g.messages["item_not_present"]
+    g.command_processor.cmd_examine("sword")
+    assert outputs[-1] == g.language_manager.messages["item_not_present"]

--- a/tests/test_npcs.py
+++ b/tests/test_npcs.py
@@ -45,13 +45,13 @@ def test_npc_state_saved_and_loaded(tmp_path):
 
 def test_npc_event_triggered_on_room_change(data_dir, capsys):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_go("Room 2")
+    g.command_processor.cmd_go("Room 2")
     out = capsys.readouterr().out
     assert "The old man greets you." in out
     assert g.world.npc_state("old_man") == "met"
-    g.cmd_go("Room 3")
+    g.command_processor.cmd_go("Room 3")
     capsys.readouterr()
-    g.cmd_go("Room 2")
+    g.command_processor.cmd_go("Room 2")
     out = capsys.readouterr().out
     assert "The old man greets you." not in out
 

--- a/tests/test_playthrough.py
+++ b/tests/test_playthrough.py
@@ -18,21 +18,22 @@ def test_game_reaches_ending(data_dir, monkeypatch):
 
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
 
+    cp = g.command_processor
     commands = [
-        lambda: g.cmd_take("Small Key"),
-        lambda: g.cmd_go("Forest"),
-        lambda: g.cmd_go("Ash Village"),
-        lambda: g.cmd_talk("Villager"),
-        lambda: g.cmd_take("Map Fragment"),
-        lambda: g.cmd_go("Forest"),
-        lambda: g.cmd_talk("Ashram"),
-        lambda: g.cmd_show("Map Fragment", "Ashram"),
-        lambda: g.cmd_go("Hut"),
-        lambda: g.cmd_go("Ruins"),
-        lambda: g.cmd_use("Small Key", "Locked Chest"),
-        lambda: g.cmd_examine("Locked Chest"),
-        lambda: g.cmd_go("Forest"),
-        lambda: g.cmd_go("Ash Village"),
+        lambda: cp.cmd_take("Small Key"),
+        lambda: cp.cmd_go("Forest"),
+        lambda: cp.cmd_go("Ash Village"),
+        lambda: cp.cmd_talk("Villager"),
+        lambda: cp.cmd_take("Map Fragment"),
+        lambda: cp.cmd_go("Forest"),
+        lambda: cp.cmd_talk("Ashram"),
+        lambda: cp.cmd_show("Map Fragment", "Ashram"),
+        lambda: cp.cmd_go("Hut"),
+        lambda: cp.cmd_go("Ruins"),
+        lambda: cp.cmd_use("Small Key", "Locked Chest"),
+        lambda: cp.cmd_examine("Locked Chest"),
+        lambda: cp.cmd_go("Forest"),
+        lambda: cp.cmd_go("Ash Village"),
     ]
 
     for func in commands:

--- a/tests/test_state_commands.py
+++ b/tests/test_state_commands.py
@@ -9,6 +9,6 @@ def test_state_command_requires_existing_state(data_dir, monkeypatch, command):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 3")
     assert g.world.take("Sword")
-    getattr(g, f"cmd_{command}")("Sword")
-    assert outputs[-1] == g.messages["use_failure"]
+    getattr(g.command_processor, f"cmd_{command}")("Sword")
+    assert outputs[-1] == g.language_manager.messages["use_failure"]
     assert "sword" in g.world.inventory

--- a/tests/test_suffix.py
+++ b/tests/test_suffix.py
@@ -3,14 +3,14 @@ from engine import game
 
 def test_strip_suffix_drop(data_dir):
     g = game.Game(str(data_dir / "de" / "world.yaml"), "de")
-    assert g._strip_suffix("stein ab", "ab") == "stein"
+    assert g.command_processor._strip_suffix("stein ab", "ab") == "stein"
 
 
 def test_strip_suffix_wear(data_dir):
     g = game.Game(str(data_dir / "de" / "world.yaml"), "de")
-    assert g._strip_suffix("hut an", "an") == "hut"
+    assert g.command_processor._strip_suffix("hut an", "an") == "hut"
 
 
 def test_strip_suffix_pair(data_dir):
     g = game.Game(str(data_dir / "de" / "world.yaml"), "de")
-    assert g._strip_suffix("stein fallen", "fallen") == "stein"
+    assert g.command_processor._strip_suffix("stein fallen", "fallen") == "stein"

--- a/tests/test_take_command.py
+++ b/tests/test_take_command.py
@@ -6,5 +6,8 @@ def test_take_uses_canonical_name(data_dir, monkeypatch):
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 3")
-    g.cmd_take("sword")
-    assert outputs[-1] == g.messages["taken"].format(item="Sword")
+    g.command_processor.cmd_take("sword")
+    assert (
+        outputs[-1]
+        == g.language_manager.messages["taken"].format(item="Sword")
+    )

--- a/tests/test_talk_command.py
+++ b/tests/test_talk_command.py
@@ -3,21 +3,21 @@ from engine import game
 
 def test_talk_requires_npc_name(data_dir, capsys):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_go("Room 2")
+    g.command_processor.cmd_go("Room 2")
     capsys.readouterr()
-    g.cmd_talk("")
+    g.command_processor.cmd_talk("")
     out = capsys.readouterr().out
     assert "I didn't understand that." in out
 
 
 def test_talk_changes_state_and_outputs_text(data_dir, capsys):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.cmd_go("Room 2")
+    g.command_processor.cmd_go("Room 2")
     capsys.readouterr()
-    g.cmd_talk("Old Man")
+    g.command_processor.cmd_talk("Old Man")
     out = capsys.readouterr().out
     assert "You tell the old man about your quest. He agrees to help." in out
     assert g.world.npc_state("old_man") == "helped"
-    g.cmd_talk("Old Man")
+    g.command_processor.cmd_talk("Old Man")
     out = capsys.readouterr().out
     assert "The old man has already offered his aid." in out

--- a/tests/test_use_command.py
+++ b/tests/test_use_command.py
@@ -8,7 +8,7 @@ def test_use_success(data_dir, monkeypatch):
     assert g.world.move("Room 3")
     assert g.world.take("Sword")
     assert g.world.move("Room 2")
-    g.cmd_use("Sword", "Gem")
+    g.command_processor.cmd_use("Sword", "Gem")
     assert g.world.item_states["gem"] == "green"
     success_msg = next(
         a["messages"]["success"]
@@ -30,7 +30,7 @@ def test_use_item_in_room(data_dir, monkeypatch):
     assert g.world.take("Sword")
     assert g.world.move("Room 2")
     assert g.world.drop("Sword")
-    g.cmd_use("Sword", "Gem")
+    g.command_processor.cmd_use("Sword", "Gem")
     assert g.world.item_states["gem"] == "green"
     success_msg = next(
         a["messages"]["success"]
@@ -51,7 +51,7 @@ def test_use_invalid(data_dir, monkeypatch):
     assert g.world.move("Room 2")
     assert g.world.take("Gem")
     assert g.world.move("Room 3")
-    g.cmd_use("Sword", "Gem")
+    g.command_processor.cmd_use("Sword", "Gem")
     assert g.world.item_states["gem"] == "red"
-    assert outputs[-1] == g.messages["use_failure"]
+    assert outputs[-1] == g.language_manager.messages["use_failure"]
 


### PR DESCRIPTION
## Summary
- Extract SaveManager for persisting game state
- Introduce LanguageManager to load and switch translations
- Move command parsing and handlers into CommandProcessor
- Update Game to orchestrate modular components

## Testing
- `ruff check .`
- `pyright`
- `pytest --cov --cov-branch -q`

------
https://chatgpt.com/codex/tasks/task_e_68b1a243857483308a651a4a961f6a2a