### PR TITLE
Refactor world model to dataclasses

### DIFF
--- a/engine/world.py
+++ b/engine/world.py
@@ -435,7 +435,13 @@ class World:
         desc = room.description
         room_items = room.items
         if room_items:
-            item_names = [self.items[i].names[0] for i in room_items]
+            item_names = []
+            for item_id in room_items:
+                item = self.items.get(item_id)
+                if item and item.names:
+                    item_names.append(item.names[0])
+                else:
+                    item_names.append(item_id)
             if messages:
                 desc += " " + messages["items_here"].format(items=", ".join(item_names))
             else:  # pragma: no cover - fallback without messages

--- a/engine/world_model.py
+++ b/engine/world_model.py
@@ -1,0 +1,37 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+@dataclass
+class Item:
+    names: List[str]
+    description: Optional[str] = None
+    states: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    state: Optional[str] = None
+
+
+@dataclass
+class Room:
+    names: List[str]
+    description: str
+    exits: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    items: List[str] = field(default_factory=list)
+
+
+@dataclass
+class Npc:
+    names: List[str]
+    states: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    state: Optional[str] = None
+    meet: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Action:
+    trigger: str
+    item: Optional[str] = None
+    target_item: Optional[str] = None
+    target_npc: Optional[str] = None
+    preconditions: Optional[Dict[str, Any]] = None
+    effect: Dict[str, Any] = field(default_factory=dict)
+    messages: Dict[str, str] = field(default_factory=dict)

--- a/tests/test_effect_item_conditions.py
+++ b/tests/test_effect_item_conditions.py
@@ -3,7 +3,7 @@ from engine import game
 
 def test_apply_effect_multiple_item_conditions(data_dir):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    assert "sword" in g.world.rooms["room3"]["items"]
+    assert "sword" in g.world.rooms["room3"].items
     g.world.apply_effect(
         {
             "item_condition": [
@@ -14,5 +14,5 @@ def test_apply_effect_multiple_item_conditions(data_dir):
     )
     assert g.world.item_states["gem"] == "green"
     assert "sword" in g.world.inventory
-    assert "sword" not in g.world.rooms["room3"]["items"]
+    assert "sword" not in g.world.rooms["room3"].items
 

--- a/tests/test_examine_action.py
+++ b/tests/test_examine_action.py
@@ -1,4 +1,5 @@
 from engine import game, io
+from engine.world_model import Action, Item
 
 
 def test_examine_triggers_action(data_dir, monkeypatch):
@@ -6,21 +7,19 @@ def test_examine_triggers_action(data_dir, monkeypatch):
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
 
-    g.world.items["stone"] = {"names": ["Stone"], "description": "A stone."}
-    g.world.items["coin"] = {"names": ["Coin"], "description": "A coin."}
-    g.world.rooms["start"].setdefault("items", []).append("stone")
+    g.world.items["stone"] = Item(names=["Stone"], description="A stone.")
+    g.world.items["coin"] = Item(names=["Coin"], description="A coin.")
+    g.world.rooms["start"].items.append("stone")
     g.world.actions.append(
-        {
-            "trigger": "examine",
-            "item": "stone",
-            "effect": {
-                "item_condition": {"item": "coin", "location": "CURRENT_ROOM"}
-            },
-            "messages": {"success": "You find a coin."},
-        }
+        Action(
+            trigger="examine",
+            item="stone",
+            effect={"item_condition": {"item": "coin", "location": "CURRENT_ROOM"}},
+            messages={"success": "You find a coin."},
+        )
     )
 
     g.describe_item("Stone")
 
     assert outputs[-2:] == ["A stone.", "You find a coin."]
-    assert "coin" in g.world.rooms[g.world.current].get("items", [])
+    assert "coin" in g.world.rooms[g.world.current].items

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -14,7 +14,7 @@ def test_language_switch(data_dir, monkeypatch):
     assert g.reverse_cmds["language"][0] == "language"
     assert g.reverse_cmds["sprache"][0] == "language"
     assert outputs[-1] == g.messages["language_set"].format(language="de")
-    assert g.world.items["sword"]["names"][0] == "Schwert"
+    assert g.world.items["sword"].names[0] == "Schwert"
 
 
 def test_language_persistence(data_dir, monkeypatch):
@@ -27,7 +27,7 @@ def test_language_persistence(data_dir, monkeypatch):
     assert g2.language == "de"
     assert g2.messages["farewell"] == "Auf Wiedersehen!"
     assert g2.reverse_cmds["language"][0] == "language"
-    assert g2.world.items["sword"]["names"][0] == "Schwert"
+    assert g2.world.items["sword"].names[0] == "Schwert"
 
 
 def test_language_command_base_word(data_dir, monkeypatch):

--- a/tests/test_npcs.py
+++ b/tests/test_npcs.py
@@ -105,6 +105,6 @@ def test_action_requires_npc_help():
     assert not w.check_preconditions(pre_help)
     assert not w.check_preconditions(pre_state)
     w.npc_states["old_man"] = "helped"
-    w.npcs["old_man"]["state"] = "helped"
+    w.npcs["old_man"].state = "helped"
     assert w.check_preconditions(pre_help)
     assert w.check_preconditions(pre_state)

--- a/tests/test_save_state_inventory.py
+++ b/tests/test_save_state_inventory.py
@@ -65,8 +65,8 @@ def test_load_state_applies_differences(tmp_path):
 
     assert new.current == "room3"
     assert new.inventory == []
-    assert new.rooms["room2"].get("items", []) == []
-    assert new.rooms["room3"].get("items", []) == ["crown", "sword"]
+    assert new.rooms["room2"].items == []
+    assert new.rooms["room3"].items == ["crown", "sword"]
     with open(save_path, encoding="utf-8") as fh:
         data = yaml.safe_load(fh)
     assert "inventory" not in data

--- a/tests/test_use_command.py
+++ b/tests/test_use_command.py
@@ -11,11 +11,11 @@ def test_use_success(data_dir, monkeypatch):
     g.cmd_use("Sword", "Gem")
     assert g.world.item_states["gem"] == "green"
     success_msg = next(
-        a["messages"]["success"]
+        a.messages["success"]
         for a in g.world.actions
-        if a.get("trigger") == "use"
-        and a.get("item") == "sword"
-        and a.get("target_item") == "gem"
+        if a.trigger == "use"
+        and a.item == "sword"
+        and a.target_item == "gem"
     )
     assert outputs[-2:] == [success_msg, "The gem is green."]
 
@@ -33,11 +33,11 @@ def test_use_item_in_room(data_dir, monkeypatch):
     g.cmd_use("Sword", "Gem")
     assert g.world.item_states["gem"] == "green"
     success_msg = next(
-        a["messages"]["success"]
+        a.messages["success"]
         for a in g.world.actions
-        if a.get("trigger") == "use"
-        and a.get("item") == "sword"
-        and a.get("target_item") == "gem"
+        if a.trigger == "use"
+        and a.item == "sword"
+        and a.target_item == "gem"
     )
     assert outputs[-2:] == [success_msg, "The gem is green."]
 

--- a/tests/test_world_describe_unknown_item.py
+++ b/tests/test_world_describe_unknown_item.py
@@ -1,0 +1,9 @@
+from engine.world import World
+
+
+def test_describe_current_handles_unknown_item(data_dir):
+    world = World.from_files(
+        data_dir / "generic/world.yaml", data_dir / "en/world.yaml"
+    )
+    world.rooms[world.current].items.append("ghost")
+    assert "ghost" in world.describe_current()

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -1,0 +1,33 @@
+from engine.world_model import Action, Item, Npc, Room
+
+
+def test_item_dataclass():
+    item = Item(names=["Key"], description="A key", state="unused")
+    assert item.names == ["Key"]
+    assert item.description == "A key"
+    assert item.state == "unused"
+    assert item.states == {}
+
+
+def test_room_dataclass():
+    room = Room(names=["Hall"], description="Desc", items=["key"], exits={"north": {"names": ["north"]}})
+    assert room.names[0] == "Hall"
+    assert room.description == "Desc"
+    assert room.items == ["key"]
+    assert "north" in room.exits
+
+
+def test_npc_dataclass():
+    npc = Npc(names=["Bob"], state="met", states={"met": {}}, meet={"location": "hall"})
+    assert npc.names == ["Bob"]
+    assert npc.state == "met"
+    assert "met" in npc.states
+    assert npc.meet["location"] == "hall"
+
+
+def test_action_dataclass():
+    action = Action(trigger="use", item="key", target_item="door", messages={"success": "ok"})
+    assert action.trigger == "use"
+    assert action.item == "key"
+    assert action.target_item == "door"
+    assert action.messages["success"] == "ok"


### PR DESCRIPTION
## Summary
- add dataclasses `Item`, `Room`, `Npc`, and `Action` to formalize world data
- refactor world engine to build and use dataclasses in place of raw dicts
- extend tests with dataclass coverage and adjust existing tests

## Testing
- `ruff .`
- `pyright`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1a257bbc083308e91dcc0988a8a7a