### PR TITLE
Robust YAML handling and tests

### DIFF
--- a/engine/i18n.py
+++ b/engine/i18n.py
@@ -5,14 +5,27 @@ from typing import Dict, List, Union
 
 import yaml
 
+from . import io
+
+
+def _load_yaml(path: Path) -> dict:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return yaml.safe_load(fh)
+    except FileNotFoundError as exc:
+        io.output(f"ERROR: Missing file '{path.name}'")
+        raise SystemExit from exc
+    except yaml.YAMLError as exc:
+        io.output(f"ERROR: Invalid YAML in '{path.name}': {exc}")
+        raise SystemExit from exc
+
 
 def load_messages(language: str) -> Dict[str, str]:
     """Load translation messages for the given language code."""
     path = (
         Path(__file__).resolve().parent.parent / "data" / language / "messages.yaml"
     )
-    with open(path, encoding="utf-8") as fh:
-        return yaml.safe_load(fh)
+    return _load_yaml(path)
 
 
 def load_commands(language: str) -> Dict[str, Union[str, List[str]]]:
@@ -20,12 +33,10 @@ def load_commands(language: str) -> Dict[str, Union[str, List[str]]]:
     path = (
         Path(__file__).resolve().parent.parent / "data" / language / "commands.yaml"
     )
-    with open(path, encoding="utf-8") as fh:
-        return yaml.safe_load(fh)
+    return _load_yaml(path)
 
 
 def load_command_info() -> Dict[str, Dict[str, int]]:
     """Return metadata about the available commands."""
     path = Path(__file__).resolve().parent.parent / "data" / "generic" / "commands.yaml"
-    with open(path, encoding="utf-8") as fh:
-        return yaml.safe_load(fh)
+    return _load_yaml(path)

--- a/engine/persistence.py
+++ b/engine/persistence.py
@@ -44,7 +44,10 @@ class SaveManager:
         """Remove the save file if it exists."""
 
         if self.save_path.exists():
-            self.save_path.unlink()
+            try:
+                self.save_path.unlink()
+            except OSError:
+                pass
 
 
 __all__ = ["SaveManager"]

--- a/tests/test_game_yaml_errors.py
+++ b/tests/test_game_yaml_errors.py
@@ -1,0 +1,33 @@
+import pytest
+
+from engine import game, io
+
+
+def test_game_init_missing_world(data_dir, monkeypatch):
+    (data_dir / "generic" / "world.yaml").unlink()
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    with pytest.raises(SystemExit):
+        game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    assert any("Missing world file" in o for o in outputs)
+
+
+def test_game_init_corrupted_world(data_dir, monkeypatch):
+    with open(data_dir / "en" / "world.yaml", "w", encoding="utf-8") as fh:
+        fh.write("- : - invalid yaml")
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    with pytest.raises(SystemExit):
+        game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    assert any("Invalid world file" in o for o in outputs)
+
+
+def test_game_init_corrupted_save(data_dir, monkeypatch):
+    with open(data_dir / "save.yaml", "w", encoding="utf-8") as fh:
+        fh.write("- : - invalid yaml")
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    with pytest.raises(SystemExit):
+        game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    assert any("save file" in o for o in outputs)
+

--- a/tests/test_i18n_errors.py
+++ b/tests/test_i18n_errors.py
@@ -1,0 +1,33 @@
+import pytest
+
+from engine import i18n, io
+
+
+def _prepare_i18n(monkeypatch, data_dir):
+    engine_dir = data_dir / "engine"
+    engine_dir.mkdir()
+    monkeypatch.setattr(i18n, "__file__", str(engine_dir / "i18n.py"))
+
+
+def test_load_messages_missing_file(data_dir, monkeypatch):
+    _prepare_i18n(monkeypatch, data_dir)
+    (data_dir / "data" / "en").mkdir(parents=True)
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    with pytest.raises(SystemExit):
+        i18n.load_messages("en")
+    assert any("Missing file" in o for o in outputs)
+
+
+def test_load_messages_corrupted(data_dir, monkeypatch):
+    _prepare_i18n(monkeypatch, data_dir)
+    path = data_dir / "data" / "en"
+    path.mkdir(parents=True)
+    with open(path / "messages.yaml", "w", encoding="utf-8") as fh:
+        fh.write("- : - invalid yaml")
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    with pytest.raises(SystemExit):
+        i18n.load_messages("en")
+    assert any("Invalid YAML" in o for o in outputs)
+


### PR DESCRIPTION
## Summary
- handle missing or malformed YAML in i18n loaders
- ensure Game initialization fails gracefully on bad or missing world/save data
- ignore unlink errors when cleaning up saves
- add tests for broken or missing YAML files

## Testing
- `ruff engine/i18n.py engine/game.py engine/persistence.py tests/test_i18n_errors.py tests/test_game_yaml_errors.py`
- `pyright engine/i18n.py engine/game.py engine/persistence.py tests/test_i18n_errors.py tests/test_game_yaml_errors.py`
- `pytest --cov --cov-branch -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1cfbf7db88330a02d0be698fee1aa