### PR TITLE
Centralize command argument validation

### DIFF
--- a/tests/test_command_arguments.py
+++ b/tests/test_command_arguments.py
@@ -1,0 +1,17 @@
+from engine import game, io
+
+
+def test_missing_argument(monkeypatch, data_dir):
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    g.command_processor.cmd_take("")
+    assert outputs[-1] == g.language_manager.messages["unknown_command"]
+
+
+def test_too_many_arguments(monkeypatch, data_dir):
+    outputs: list[str] = []
+    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    g.command_processor.execute("inventory extra")
+    assert outputs[-1] == g.language_manager.messages["unknown_command"]

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -25,7 +25,7 @@ def test_language_persistence(data_dir, monkeypatch):
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     g.command_processor.cmd_language("de")
-    g.command_processor.cmd_quit("")
+    g.command_processor.cmd_quit()
     g2 = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g2.language == "de"
     assert g2.language_manager.messages["farewell"] == "Auf Wiedersehen!"

--- a/tests/test_look_exits.py
+++ b/tests/test_look_exits.py
@@ -5,7 +5,7 @@ def test_room_description_lists_exits(data_dir, monkeypatch):
     outputs: list[str] = []
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    g.command_processor.cmd_look("")
+    g.command_processor.cmd_look()
     assert outputs[-1] == "Room 1. Exits: Room 2, Room 3."
 
 
@@ -14,7 +14,7 @@ def test_room_description_lists_items_npcs_and_exits(data_dir, monkeypatch):
     monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert g.world.move("Room 2")
-    g.command_processor.cmd_look("")
+    g.command_processor.cmd_look()
     assert (
         outputs[-1]
         == "Room 2. You see here: Gem. You see here: Old Man. Exits: Room 1, Room 3."


### PR DESCRIPTION
## Summary
- add `require_args` decorator to centralize argument checks
- refactor command handlers to rely on decorator and improve dispatch
- add tests for missing and extra command arguments

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1cfdfadb4833096952078304e8d54