### PR TITLE
Injectable IO and LLM backends with protocol interfaces

### DIFF
--- a/engine/game.py
+++ b/engine/game.py
@@ -6,7 +6,10 @@ from pathlib import Path
 
 import yaml
 
-from engine import io, parser, world, llm, integrity
+from engine import parser, world, integrity
+from .interfaces import IOBackend, LLMBackend
+from .io import ConsoleIO
+from .llm import NoOpLLM
 
 from .commands import CommandProcessor
 from .language import LanguageManager
@@ -14,16 +17,25 @@ from .persistence import SaveManager
 
 
 class Game:
-    def __init__(self, world_data_path: str, language: str, debug: bool = False) -> None:
+    def __init__(
+        self,
+        world_data_path: str,
+        language: str,
+        io_backend: IOBackend | None = None,
+        llm_backend: LLMBackend | None = None,
+        debug: bool = False,
+    ) -> None:
         data_path = Path(world_data_path)
         self.data_dir = data_path.parent.parent
         self.debug = debug
+        self.io = io_backend or ConsoleIO()
+        self.llm = llm_backend or NoOpLLM()
         self.save_manager = SaveManager(self.data_dir)
 
         try:
             save_data = self.save_manager.load()
         except (FileNotFoundError, yaml.YAMLError) as exc:
-            io.output(f"ERROR: Failed to load save file: {exc}")
+            self.io.output(f"ERROR: Failed to load save file: {exc}")
             raise SystemExit from exc
 
         self._show_intro = not save_data
@@ -34,19 +46,19 @@ class Game:
         try:
             self.world = world.World.from_files(generic_path, lang_world_path, debug=debug)
         except FileNotFoundError as exc:
-            io.output(f"ERROR: Missing world file: {exc}")
+            self.io.output(f"ERROR: Missing world file: {exc}")
             raise SystemExit from exc
         except yaml.YAMLError as exc:
-            io.output(f"ERROR: Invalid world file: {exc}")
+            self.io.output(f"ERROR: Invalid world file: {exc}")
             raise SystemExit from exc
 
         try:
             warnings = integrity.check_translations(self._language, self.data_dir)
         except (FileNotFoundError, yaml.YAMLError) as exc:
-            io.output(f"ERROR: Failed to load translations: {exc}")
+            self.io.output(f"ERROR: Failed to load translations: {exc}")
             raise SystemExit from exc
         for msg in warnings:
-            io.output(f"WARNING: {msg}")
+            self.io.output(f"WARNING: {msg}")
 
         errors = integrity.validate_world_structure(self.world)
         if save_data:
@@ -54,7 +66,7 @@ class Game:
 
         if errors:
             for msg in errors:
-                io.output(f"ERROR: {msg}")
+                self.io.output(f"ERROR: {msg}")
             raise SystemExit("Integrity check failed")
 
         if save_data:
@@ -62,7 +74,7 @@ class Game:
             self.save_manager.cleanup()
 
         self.language_manager = LanguageManager(
-            self.data_dir, self._language, debug=debug
+            self.data_dir, self._language, self.io, debug=debug
         )
         self.command_processor = CommandProcessor(
             self.world,
@@ -72,6 +84,7 @@ class Game:
             self._check_npc_event,
             self.stop,
             self._update_world,
+            self.io,
         )
         self.running = True
 
@@ -88,7 +101,7 @@ class Game:
     def _check_end(self) -> None:
         ending = self.world.check_endings()
         if ending:
-            io.output(ending)
+            self.io.output(ending)
             self.running = False
 
     def _check_npc_event(self) -> None:
@@ -101,27 +114,39 @@ class Game:
                 if pre and not self.world.check_preconditions(pre):
                     continue
                 if text:
-                    io.output(text)
+                    self.io.output(text)
                 self.world.meet_npc(npc_id)
 
     def run(self) -> None:
         if self._show_intro and self.world.intro:
-            io.output(self.world.intro)
-        io.output(self.world.describe_current(self.language_manager.messages))
+            self.io.output(self.world.intro)
+        self.io.output(self.world.describe_current(self.language_manager.messages))
         self._check_npc_event()
         self._check_end()
         try:
             while self.running:
-                raw = io.get_input()
-                raw = llm.interpret(raw)
+                raw = self.io.get_input()
+                raw = self.llm.interpret(raw)
                 raw = parser.parse(raw)
                 self.command_processor.execute(raw)
         except (EOFError, KeyboardInterrupt):
-            io.output(self.language_manager.messages["farewell"])
+            self.io.output(self.language_manager.messages["farewell"])
         finally:
             self.save_manager.save(self.world, self.language_manager.language)
 
 
-def run(world_data_path: str, language: str = "en", debug: bool = False) -> None:
-    Game(world_data_path, language, debug=debug).run()
+def run(
+    world_data_path: str,
+    language: str = "en",
+    io_backend: IOBackend | None = None,
+    llm_backend: LLMBackend | None = None,
+    debug: bool = False,
+) -> None:
+    Game(
+        world_data_path,
+        language,
+        io_backend=io_backend,
+        llm_backend=llm_backend,
+        debug=debug,
+    ).run()
 

--- a/engine/i18n.py
+++ b/engine/i18n.py
@@ -5,10 +5,10 @@ from typing import Dict, List, Union
 
 import yaml
 
-from . import io
+from .interfaces import IOBackend
 
 
-def _load_yaml(path: Path) -> dict:
+def _load_yaml(path: Path, io: IOBackend) -> dict:
     try:
         with open(path, encoding="utf-8") as fh:
             return yaml.safe_load(fh)
@@ -20,23 +20,23 @@ def _load_yaml(path: Path) -> dict:
         raise SystemExit from exc
 
 
-def load_messages(language: str) -> Dict[str, str]:
+def load_messages(language: str, io: IOBackend) -> Dict[str, str]:
     """Load translation messages for the given language code."""
     path = (
         Path(__file__).resolve().parent.parent / "data" / language / "messages.yaml"
     )
-    return _load_yaml(path)
+    return _load_yaml(path, io)
 
 
-def load_commands(language: str) -> Dict[str, Union[str, List[str]]]:
+def load_commands(language: str, io: IOBackend) -> Dict[str, Union[str, List[str]]]:
     """Load command translations for the given language code."""
     path = (
         Path(__file__).resolve().parent.parent / "data" / language / "commands.yaml"
     )
-    return _load_yaml(path)
+    return _load_yaml(path, io)
 
 
-def load_command_info() -> Dict[str, Dict[str, int]]:
+def load_command_info(io: IOBackend) -> Dict[str, Dict[str, int]]:
     """Return metadata about the available commands."""
     path = Path(__file__).resolve().parent.parent / "data" / "generic" / "commands.yaml"
-    return _load_yaml(path)
+    return _load_yaml(path, io)

--- a/engine/interfaces.py
+++ b/engine/interfaces.py
@@ -1,0 +1,28 @@
+"""Protocol interfaces for engine backends."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class IOBackend(Protocol):
+    """Interface for input and output backends."""
+
+    def get_input(self, prompt: str = "> ") -> str:  # pragma: no cover - interface
+        """Return user input for the given prompt."""
+
+    def output(self, text: str) -> None:  # pragma: no cover - interface
+        """Display ``text`` to the user."""
+
+
+@runtime_checkable
+class LLMBackend(Protocol):
+    """Interface for language model helpers."""
+
+    def interpret(self, command: str) -> str:  # pragma: no cover - interface
+        """Return a normalized version of ``command``."""
+
+
+__all__ = ["IOBackend", "LLMBackend"]
+

--- a/engine/io.py
+++ b/engine/io.py
@@ -1,7 +1,19 @@
-"""Simple input and output helpers."""
+"""Input and output backend using the console."""
 
-def get_input(prompt: str = "> ") -> str:
-    return input(prompt)
+from __future__ import annotations
 
-def output(text: str) -> None:
-    print(text)
+from .interfaces import IOBackend
+
+
+class ConsoleIO(IOBackend):
+    """Read from stdin and write to stdout."""
+
+    def get_input(self, prompt: str = "> ") -> str:
+        return input(prompt)
+
+    def output(self, text: str) -> None:
+        print(text)
+
+
+__all__ = ["ConsoleIO"]
+

--- a/engine/language.py
+++ b/engine/language.py
@@ -4,20 +4,23 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from . import i18n, world
+from . import world
 from .persistence import SaveManager
+from .interfaces import IOBackend
+from . import i18n
 
 
 class LanguageManager:
     """Manage messages, command translations and language switches."""
 
-    def __init__(self, data_dir: Path, language: str, debug: bool = False):
+    def __init__(self, data_dir: Path, language: str, io: IOBackend, debug: bool = False):
         self.data_dir = data_dir
         self.debug = debug
+        self.io = io
         self.language = language
-        self.messages = i18n.load_messages(language)
-        self.commands = i18n.load_commands(language)
-        self.command_info = i18n.load_command_info()
+        self.messages = i18n.load_messages(language, io)
+        self.commands = i18n.load_commands(language, io)
+        self.command_info = i18n.load_command_info(io)
 
     def switch(self, language: str, current_world: world.World, save_manager: SaveManager) -> world.World:
         """Switch the game to a different language.
@@ -27,8 +30,8 @@ class LanguageManager:
         """
 
         try:
-            messages = i18n.load_messages(language)
-            commands = i18n.load_commands(language)
+            messages = i18n.load_messages(language, self.io)
+            commands = i18n.load_commands(language, self.io)
             generic_path = self.data_dir / "generic" / "world.yaml"
             world_path = self.data_dir / language / "world.yaml"
             new_world = world.World.from_files(generic_path, world_path, debug=self.debug)

--- a/engine/llm.py
+++ b/engine/llm.py
@@ -1,5 +1,16 @@
-"""Placeholder for LLM integration via ollama."""
+"""Placeholder LLM backend."""
 
-def interpret(command: str) -> str:
-    """For now, simply return the command unchanged."""
-    return command
+from __future__ import annotations
+
+from .interfaces import LLMBackend
+
+
+class NoOpLLM(LLMBackend):
+    """Backend that returns the command unchanged."""
+
+    def interpret(self, command: str) -> str:
+        return command
+
+
+__all__ = ["NoOpLLM"]
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,35 @@ ROOT_DIR = Path(__file__).resolve().parents[1]
 if str(ROOT_DIR) not in sys.path:
     sys.path.append(str(ROOT_DIR))
 
+from engine.interfaces import IOBackend, LLMBackend
+
+
+class DummyIO(IOBackend):
+    def __init__(self, inputs: list[str] | None = None) -> None:
+        self.inputs = inputs or []
+        self.outputs: list[str] = []
+
+    def get_input(self, prompt: str = "> ") -> str:
+        return self.inputs.pop(0) if self.inputs else ""
+
+    def output(self, text: str) -> None:
+        self.outputs.append(text)
+
+
+class DummyLLM(LLMBackend):
+    def interpret(self, command: str) -> str:
+        return command
+
+
+@pytest.fixture
+def io_backend() -> DummyIO:
+    return DummyIO()
+
+
+@pytest.fixture
+def llm_backend() -> DummyLLM:
+    return DummyLLM()
+
 
 @pytest.fixture
 def data_dir(tmp_path):

--- a/tests/test_auto_save.py
+++ b/tests/test_auto_save.py
@@ -1,15 +1,15 @@
 import yaml
 import pytest
-from engine import game, io, parser
+from engine import game, parser
 
 
-def test_save_on_eoferror(data_dir, monkeypatch):
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_save_on_eoferror(data_dir, monkeypatch, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
 
     def fake_input(prompt: str = "> ") -> str:  # noqa: ARG001
         raise EOFError
 
-    monkeypatch.setattr(io, "get_input", fake_input)
+    monkeypatch.setattr(io_backend, "get_input", fake_input)
     g.run()
     save_path = data_dir / "save.yaml"
     assert save_path.exists()
@@ -18,9 +18,9 @@ def test_save_on_eoferror(data_dir, monkeypatch):
     assert data["current"] == "start"
 
 
-def test_save_on_exception(data_dir, monkeypatch):
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    monkeypatch.setattr(io, "get_input", lambda prompt="> ": "look")
+def test_save_on_exception(data_dir, monkeypatch, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
+    monkeypatch.setattr(io_backend, "get_input", lambda prompt="> ": "look")
 
     def boom(cmd: str) -> str:  # noqa: ARG001
         raise ValueError("boom")

--- a/tests/test_command_arguments.py
+++ b/tests/test_command_arguments.py
@@ -1,17 +1,13 @@
-from engine import game, io
+from engine import game
 
 
-def test_missing_argument(monkeypatch, data_dir):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_missing_argument(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_take("")
-    assert outputs[-1] == g.language_manager.messages["unknown_command"]
+    assert io_backend.outputs[-1] == g.language_manager.messages["unknown_command"]
 
 
-def test_too_many_arguments(monkeypatch, data_dir):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_too_many_arguments(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.execute("inventory extra")
-    assert outputs[-1] == g.language_manager.messages["unknown_command"]
+    assert io_backend.outputs[-1] == g.language_manager.messages["unknown_command"]

--- a/tests/test_endings.py
+++ b/tests/test_endings.py
@@ -1,8 +1,8 @@
 import yaml
-from engine import game, io
+from engine import game
 
 
-def test_end_condition_inventory_and_location(data_dir, monkeypatch):
+def test_end_condition_inventory_and_location(data_dir, io_backend):
     generic = {
         "items": {"crown": {}},
         "rooms": {
@@ -31,15 +31,13 @@ def test_end_condition_inventory_and_location(data_dir, monkeypatch):
         yaml.safe_dump(generic, fh)
     with open(data_dir / "en" / "world.yaml", "w", encoding="utf-8") as fh:
         yaml.safe_dump(en, fh)
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_take("Crown")
     g.command_processor.cmd_go("Room2")
-    assert outputs[-1] == "You win!"
+    assert io_backend.outputs[-1] == "You win!"
 
 
-def test_end_condition_inventory_lacks(data_dir, monkeypatch):
+def test_end_condition_inventory_lacks(data_dir, io_backend):
     generic = {
         "items": {"crown": {}},
         "rooms": {
@@ -68,14 +66,12 @@ def test_end_condition_inventory_lacks(data_dir, monkeypatch):
         yaml.safe_dump(generic, fh)
     with open(data_dir / "en" / "world.yaml", "w", encoding="utf-8") as fh:
         yaml.safe_dump(en, fh)
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_go("Room2")
-    assert outputs[-1] == "No crown, no victory."
+    assert io_backend.outputs[-1] == "No crown, no victory."
 
 
-def test_end_condition_or_room_has(data_dir, monkeypatch):
+def test_end_condition_or_room_has(data_dir, io_backend):
     generic = {
         "items": {"sword": {}},
         "rooms": {
@@ -104,22 +100,16 @@ def test_end_condition_or_room_has(data_dir, monkeypatch):
         yaml.safe_dump(generic, fh)
     with open(data_dir / "en" / "world.yaml", "w", encoding="utf-8") as fh:
         yaml.safe_dump(en, fh)
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_go("Room2")
-    assert outputs[-1] == "You see the sword and know your quest is over."
+    assert io_backend.outputs[-1] == "You see the sword and know your quest is over."
 
 
-
-
-def test_end_condition_item_state(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_end_condition_item_state(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g._check_end()
-    assert outputs == []
+    assert io_backend.outputs == []
     assert g.world.set_item_state("gem", "green")
     g._check_end()
-    assert outputs[-1] == "The gem is green."
+    assert io_backend.outputs[-1] == "The gem is green."
 

--- a/tests/test_examine_action.py
+++ b/tests/test_examine_action.py
@@ -1,11 +1,9 @@
-from engine import game, io
+from engine import game
 from engine.world_model import Action, Item
 
 
-def test_examine_triggers_action(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_examine_triggers_action(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
 
     g.world.items["stone"] = Item(names=["Stone"], description="A stone.")
     g.world.items["coin"] = Item(names=["Coin"], description="A coin.")
@@ -21,5 +19,5 @@ def test_examine_triggers_action(data_dir, monkeypatch):
 
     g.command_processor.describe_item("Stone")
 
-    assert outputs[-2:] == ["A stone.", "You find a coin."]
+    assert io_backend.outputs[-2:] == ["A stone.", "You find a coin."]
     assert "coin" in g.world.rooms[g.world.current].get("items", [])

--- a/tests/test_exit_conditions.py
+++ b/tests/test_exit_conditions.py
@@ -1,24 +1,21 @@
 from pathlib import Path
 import shutil
 
-from engine import game, io
+from engine import game
 
 
-def test_ruins_inaccessible_without_map(data_dir, monkeypatch):
+def test_ruins_inaccessible_without_map(data_dir, io_backend):
     root = Path(__file__).resolve().parents[1]
     shutil.copy(root / "data" / "generic" / "world.yaml", data_dir / "generic" / "world.yaml")
     shutil.copy(root / "data" / "en" / "world.yaml", data_dir / "en" / "world.yaml")
 
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_go("Forest")
     assert g.world.current == "forest"
 
     g.command_processor.cmd_go("Ruins")
     assert g.world.current == "forest"
-    assert outputs[-1] == g.language_manager.messages["cannot_move"]
+    assert io_backend.outputs[-1] == g.language_manager.messages["cannot_move"]
 
     g.command_processor.cmd_go("Ash Village")
     g.command_processor.cmd_talk("Villager")

--- a/tests/test_game_yaml_errors.py
+++ b/tests/test_game_yaml_errors.py
@@ -1,33 +1,27 @@
 import pytest
 
-from engine import game, io
+from engine import game
 
 
-def test_game_init_missing_world(data_dir, monkeypatch):
+def test_game_init_missing_world(data_dir, io_backend):
     (data_dir / "generic" / "world.yaml").unlink()
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     with pytest.raises(SystemExit):
-        game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    assert any("Missing world file" in o for o in outputs)
+        game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
+    assert any("Missing world file" in o for o in io_backend.outputs)
 
 
-def test_game_init_corrupted_world(data_dir, monkeypatch):
+def test_game_init_corrupted_world(data_dir, io_backend):
     with open(data_dir / "en" / "world.yaml", "w", encoding="utf-8") as fh:
         fh.write("- : - invalid yaml")
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     with pytest.raises(SystemExit):
-        game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    assert any("Invalid world file" in o for o in outputs)
+        game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
+    assert any("Invalid world file" in o for o in io_backend.outputs)
 
 
-def test_game_init_corrupted_save(data_dir, monkeypatch):
+def test_game_init_corrupted_save(data_dir, io_backend):
     with open(data_dir / "save.yaml", "w", encoding="utf-8") as fh:
         fh.write("- : - invalid yaml")
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     with pytest.raises(SystemExit):
-        game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    assert any("save file" in o for o in outputs)
+        game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
+    assert any("save file" in o for o in io_backend.outputs)
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -1,10 +1,8 @@
-from engine import game, io
+from engine import game
 
 
-def test_help_lists_commands(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_help_lists_commands(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_help("")
     names = []
     for key in g.command_processor.command_keys:
@@ -13,13 +11,11 @@ def test_help_lists_commands(data_dir, monkeypatch):
         first = entries[0]
         names.append(first.split()[0])
     expected = g.language_manager.messages["help"].format(commands=", ".join(names))
-    assert outputs[-1] == expected
+    assert io_backend.outputs[-1] == expected
 
 
-def test_help_lists_synonyms(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_help_lists_synonyms(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_help("destroy")
     entries = g.language_manager.commands["destroy"]
     usages = [e.replace("$a", "<>").replace("$b", "<>") for e in entries]
@@ -28,16 +24,14 @@ def test_help_lists_synonyms(data_dir, monkeypatch):
         + "\n"
         + "\n".join(usages)
     )
-    assert outputs[-1] == expected
+    assert io_backend.outputs[-1] == expected
 
 
-def test_help_optional_argument(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_help_optional_argument(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_help("help")
     expected = (
         g.language_manager.messages["help_usage"].format(command="help")
         + "\nhelp <>\nh <>"
     )
-    assert outputs[-1] == expected
+    assert io_backend.outputs[-1] == expected

--- a/tests/test_i18n_errors.py
+++ b/tests/test_i18n_errors.py
@@ -1,6 +1,6 @@
 import pytest
 
-from engine import i18n, io
+from engine import i18n
 
 
 def _prepare_i18n(monkeypatch, data_dir):
@@ -9,25 +9,21 @@ def _prepare_i18n(monkeypatch, data_dir):
     monkeypatch.setattr(i18n, "__file__", str(engine_dir / "i18n.py"))
 
 
-def test_load_messages_missing_file(data_dir, monkeypatch):
+def test_load_messages_missing_file(data_dir, monkeypatch, io_backend):
     _prepare_i18n(monkeypatch, data_dir)
     (data_dir / "data" / "en").mkdir(parents=True)
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     with pytest.raises(SystemExit):
-        i18n.load_messages("en")
-    assert any("Missing file" in o for o in outputs)
+        i18n.load_messages("en", io_backend)
+    assert any("Missing file" in o for o in io_backend.outputs)
 
 
-def test_load_messages_corrupted(data_dir, monkeypatch):
+def test_load_messages_corrupted(data_dir, monkeypatch, io_backend):
     _prepare_i18n(monkeypatch, data_dir)
     path = data_dir / "data" / "en"
     path.mkdir(parents=True)
     with open(path / "messages.yaml", "w", encoding="utf-8") as fh:
         fh.write("- : - invalid yaml")
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
     with pytest.raises(SystemExit):
-        i18n.load_messages("en")
-    assert any("Invalid YAML" in o for o in outputs)
+        i18n.load_messages("en", io_backend)
+    assert any("Invalid YAML" in o for o in io_backend.outputs)
 

--- a/tests/test_integrity.py
+++ b/tests/test_integrity.py
@@ -1,7 +1,7 @@
 import pytest
 import yaml
 
-from engine import game, io, integrity, world
+from engine import game, integrity, world
 
 
 def test_invalid_exit_causes_error(data_dir, capsys):
@@ -43,17 +43,17 @@ def test_invalid_npc_location_causes_error(data_dir, capsys):
     assert "nowhere" in out
 
 
-def test_missing_action_translation_warns(data_dir, monkeypatch):
+def test_missing_action_translation_warns(data_dir, io_backend):
     en_path = data_dir / "en" / "world.yaml"
     with open(en_path, encoding="utf-8") as fh:
         en_world = yaml.safe_load(fh)
     en_world["actions"].pop("cut_gem")
     with open(en_path, "w", encoding="utf-8") as fh:
         yaml.safe_dump(en_world, fh)
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    game.Game(str(data_dir / "en" / "world.yaml"), "en")
-    assert any("Missing translation for action 'cut_gem'" in o for o in outputs)
+    game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
+    assert any(
+        "Missing translation for action 'cut_gem'" in o for o in io_backend.outputs
+    )
 
 
 def test_validate_save_finds_errors(data_dir):

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -1,10 +1,8 @@
-from engine import game, io
+from engine import game
 
 
-def test_language_switch(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_language_switch(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_language("de")
     assert g.language_manager.messages["farewell"] == "Auf Wiedersehen!"
     assert g.language_manager.commands["look"][0] == "umschau"
@@ -14,33 +12,29 @@ def test_language_switch(data_dir, monkeypatch):
     assert g.command_processor.reverse_cmds["language"][0] == "language"
     assert g.command_processor.reverse_cmds["sprache"][0] == "language"
     assert (
-        outputs[-1]
+        io_backend.outputs[-1]
         == g.language_manager.messages["language_set"].format(language="de")
     )
     assert g.world.items["sword"]["names"][0] == "Schwert"
 
 
-def test_language_persistence(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_language_persistence(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_language("de")
     g.command_processor.cmd_quit()
-    g2 = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    g2 = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     assert g2.language == "de"
     assert g2.language_manager.messages["farewell"] == "Auf Wiedersehen!"
     assert g2.command_processor.reverse_cmds["language"][0] == "language"
     assert g2.world.items["sword"]["names"][0] == "Schwert"
 
 
-def test_language_command_base_word(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "de" / "world.yaml"), "de")
+def test_language_command_base_word(data_dir, io_backend):
+    g = game.Game(str(data_dir / "de" / "world.yaml"), "de", io_backend=io_backend)
     cmd, _ = g.command_processor.reverse_cmds["language"]
     getattr(g.command_processor, f"cmd_{cmd}")("en")
     assert g.language == "en"
     assert (
-        outputs[-1]
+        io_backend.outputs[-1]
         == g.language_manager.messages["language_set"].format(language="en")
     )

--- a/tests/test_look_exits.py
+++ b/tests/test_look_exits.py
@@ -1,21 +1,17 @@
-from engine import game, io
+from engine import game
 
 
-def test_room_description_lists_exits(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_room_description_lists_exits(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_look()
-    assert outputs[-1] == "Room 1. Exits: Room 2, Room 3."
+    assert io_backend.outputs[-1] == "Room 1. Exits: Room 2, Room 3."
 
 
-def test_room_description_lists_items_npcs_and_exits(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_room_description_lists_items_npcs_and_exits(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     assert g.world.move("Room 2")
     g.command_processor.cmd_look()
     assert (
-        outputs[-1]
+        io_backend.outputs[-1]
         == "Room 2. You see here: Gem. You see here: Old Man. Exits: Room 1, Room 3."
     )

--- a/tests/test_look_item.py
+++ b/tests/test_look_item.py
@@ -1,19 +1,15 @@
-from engine import game, io
+from engine import game
 
 
-def test_look_item_describes(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_look_item_describes(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     assert g.world.move("Room 2")
     g.command_processor.cmd_examine("gem")
-    assert outputs[-1] == "A red gem."
+    assert io_backend.outputs[-1] == "A red gem."
 
 
-def test_look_item_not_present(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_look_item_not_present(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     assert g.world.move("Room 2")
     g.command_processor.cmd_examine("sword")
-    assert outputs[-1] == g.language_manager.messages["item_not_present"]
+    assert io_backend.outputs[-1] == g.language_manager.messages["item_not_present"]

--- a/tests/test_npcs.py
+++ b/tests/test_npcs.py
@@ -1,6 +1,6 @@
 import yaml
 from engine.world import World
-from engine import game, io
+from engine import game
 
 
 def make_world() -> World:
@@ -56,7 +56,7 @@ def test_npc_event_triggered_on_room_change(data_dir, capsys):
     assert "The old man greets you." not in out
 
 
-def test_npc_event_triggered_on_start(tmp_path, monkeypatch):
+def test_npc_event_triggered_on_start(tmp_path, monkeypatch, io_backend):
     (tmp_path / "generic").mkdir()
     (tmp_path / "en").mkdir()
 
@@ -80,11 +80,10 @@ def test_npc_event_triggered_on_start(tmp_path, monkeypatch):
     with open(tmp_path / "en" / "world.yaml", "w", encoding="utf-8") as fh:
         yaml.safe_dump(en, fh)
 
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    monkeypatch.setattr(io, "get_input", lambda: (_ for _ in ()).throw(EOFError()))
+    outputs = io_backend.outputs
+    monkeypatch.setattr(io_backend, "get_input", lambda prompt='> ': (_ for _ in ()).throw(EOFError()))
 
-    g = game.Game(str(tmp_path / "en" / "world.yaml"), "en")
+    g = game.Game(str(tmp_path / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.run()
 
     assert "Hello there." in outputs

--- a/tests/test_parser_io.py
+++ b/tests/test_parser_io.py
@@ -1,6 +1,7 @@
 import builtins
 
-from engine import io, parser
+from engine import parser
+from engine.io import ConsoleIO
 
 
 def test_parse_normalizes():
@@ -8,11 +9,13 @@ def test_parse_normalizes():
 
 
 def test_get_input(monkeypatch):
+    console = ConsoleIO()
     monkeypatch.setattr(builtins, "input", lambda prompt="": "value")
-    assert io.get_input("?") == "value"
+    assert console.get_input("?") == "value"
 
 
 def test_output(capsys):
-    io.output("text")
+    console = ConsoleIO()
+    console.output("text")
     assert capsys.readouterr().out.strip() == "text"
 

--- a/tests/test_playthrough.py
+++ b/tests/test_playthrough.py
@@ -1,10 +1,10 @@
 import shutil
 from pathlib import Path
 import yaml
-from engine import game, io
+from engine import game
 
 
-def test_game_reaches_ending(data_dir, monkeypatch):
+def test_game_reaches_ending(data_dir, io_backend):
     root = Path(__file__).resolve().parents[1]
     shutil.copy(root / "data" / "generic" / "world.yaml", data_dir / "generic" / "world.yaml")
     shutil.copy(root / "data" / "en" / "world.yaml", data_dir / "en" / "world.yaml")
@@ -13,10 +13,7 @@ def test_game_reaches_ending(data_dir, monkeypatch):
         en = yaml.safe_load(fh)
     ending_text = en["endings"]["crown_returned"]
 
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
 
     cp = g.command_processor
     commands = [
@@ -39,4 +36,4 @@ def test_game_reaches_ending(data_dir, monkeypatch):
     for func in commands:
         func()
 
-    assert outputs[-1] == ending_text
+    assert io_backend.outputs[-1] == ending_text

--- a/tests/test_state_commands.py
+++ b/tests/test_state_commands.py
@@ -1,14 +1,12 @@
 import pytest
-from engine import game, io
+from engine import game
 
 
 @pytest.mark.parametrize("command", ["destroy", "wear"])
-def test_state_command_requires_existing_state(data_dir, monkeypatch, command):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_state_command_requires_existing_state(data_dir, io_backend, command):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     assert g.world.move("Room 3")
     assert g.world.take("Sword")
     getattr(g.command_processor, f"cmd_{command}")("Sword")
-    assert outputs[-1] == g.language_manager.messages["use_failure"]
+    assert io_backend.outputs[-1] == g.language_manager.messages["use_failure"]
     assert "sword" in g.world.inventory

--- a/tests/test_take_command.py
+++ b/tests/test_take_command.py
@@ -1,13 +1,11 @@
-from engine import game, io
+from engine import game
 
 
-def test_take_uses_canonical_name(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_take_uses_canonical_name(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     assert g.world.move("Room 3")
     g.command_processor.cmd_take("sword")
     assert (
-        outputs[-1]
+        io_backend.outputs[-1]
         == g.language_manager.messages["taken"].format(item="Sword")
     )

--- a/tests/test_use_command.py
+++ b/tests/test_use_command.py
@@ -1,10 +1,8 @@
-from engine import game, io
+from engine import game
 
 
-def test_use_success(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_use_success(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     assert g.world.move("Room 3")
     assert g.world.take("Sword")
     assert g.world.move("Room 2")
@@ -17,13 +15,11 @@ def test_use_success(data_dir, monkeypatch):
         and a.get("item") == "sword"
         and a.get("target_item") == "gem"
     )
-    assert outputs[-2:] == [success_msg, "The gem is green."]
+    assert io_backend.outputs[-2:] == [success_msg, "The gem is green."]
 
 
-def test_use_item_in_room(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_use_item_in_room(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     assert g.world.move("Room 2")
     assert g.world.take("Gem")
     assert g.world.move("Room 3")
@@ -39,13 +35,11 @@ def test_use_item_in_room(data_dir, monkeypatch):
         and a.get("item") == "sword"
         and a.get("target_item") == "gem"
     )
-    assert outputs[-2:] == [success_msg, "The gem is green."]
+    assert io_backend.outputs[-2:] == [success_msg, "The gem is green."]
 
 
-def test_use_invalid(data_dir, monkeypatch):
-    outputs: list[str] = []
-    monkeypatch.setattr(io, "output", lambda text: outputs.append(text))
-    g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
+def test_use_invalid(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
     assert g.world.move("Room 3")
     assert g.world.take("Sword")
     assert g.world.move("Room 2")
@@ -53,5 +47,5 @@ def test_use_invalid(data_dir, monkeypatch):
     assert g.world.move("Room 3")
     g.command_processor.cmd_use("Sword", "Gem")
     assert g.world.item_states["gem"] == "red"
-    assert outputs[-1] == g.language_manager.messages["use_failure"]
+    assert io_backend.outputs[-1] == g.language_manager.messages["use_failure"]
 


### PR DESCRIPTION
## Summary
- Introduce `IOBackend` and `LLMBackend` protocols with default `ConsoleIO` and `NoOpLLM` implementations
- Refactor `Game` and `CommandProcessor` to accept injected backend instances instead of module-level functions
- Provide dummy backends for tests and update test suite for new interfaces

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d229c5448330be0d3021bc51f78c