### PR TITLE
Add CLI entrypoint and test for module execution

### DIFF
--- a/game/main.py
+++ b/game/main.py
@@ -1,19 +1,19 @@
 """Entry point for running the sample adventure."""
 
 from pathlib import Path
-import sys
 import argparse
 
-# Ensure repository root is on the path when executed directly
-sys.path.append(str(Path(__file__).resolve().parent.parent))
-
-from engine.game import run  # noqa: E402
+from engine.game import run
 
 
-if __name__ == "__main__":
+def run_cli() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--language", default="de")
     parser.add_argument("--debug", action="store_true")
     args = parser.parse_args()
     data_path = Path(__file__).parent.parent / "data" / args.language / "world.yaml"
     run(str(data_path), language=args.language, debug=args.debug)
+
+
+if __name__ == "__main__":
+    run_cli()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ pytest-cov = "^5.0"
 pyright = "^1.1"
 ruff = "*"
 
+[tool.poetry.scripts]
+"herrschaft-der-asche" = "game.main:run_cli"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/test_cli_entry.py
+++ b/tests/test_cli_entry.py
@@ -1,0 +1,27 @@
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_cli_module_entry(data_dir, tmp_path):
+    game_dir = tmp_path / "game"
+    game_dir.mkdir()
+    main_src = Path(__file__).resolve().parents[1] / "game" / "main.py"
+    shutil.copy(main_src, game_dir / "main.py")
+    (game_dir / "__init__.py").write_text("")
+    shutil.copytree(data_dir, tmp_path / "data")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(Path(__file__).resolve().parents[1])
+    result = subprocess.run(
+        [sys.executable, "-m", "game.main", "--language", "en"],
+        input="",
+        text=True,
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Room 1." in result.stdout


### PR DESCRIPTION
## Summary
- replace manual path hack with run_cli() in game.main
- expose run_cli via poetry console script
- add test verifying `python -m game.main` works with test data

## Testing
- `ruff game/main.py tests/test_cli_entry.py`
- `pyright game/main.py tests/test_cli_entry.py`
- `pytest --cov --cov-branch -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d22d5664833083d76c1c09162f81