### PR TITLE
Add CI workflow for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry install --no-interaction --with dev
+      - name: Ruff
+        id: ruff
+        run: poetry run ruff .
+        continue-on-error: true
+      - name: Pyright
+        id: pyright
+        run: poetry run pyright
+        continue-on-error: true
+      - name: Pytest
+        id: pytest
+        run: poetry run pytest -q
+        continue-on-error: true
+      - name: Fail if any step failed
+        if: steps.ruff.outcome == 'failure' || steps.pyright.outcome == 'failure' || steps.pytest.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running ruff, pyright, and pytest

## Testing
- `pytest -q`
- `ruff .` (fails: Undefined name `IOBackend` etc.)
- `pyright` (fails: `IOBackend` is not defined)


------
https://chatgpt.com/codex/tasks/task_e_68b1d5f9d7248330bec851c9a6a8648d