### PR TITLE
Add gameplay logging and show_log command

### DIFF
--- a/engine/game.py
+++ b/engine/game.py
@@ -69,6 +69,7 @@ class Game:
                 self.io.output(f"ERROR: {msg}")
             raise SystemExit("Integrity check failed")
 
+        log_data = save_data.get("log") if save_data else None
         if save_data:
             self.world.load_state(self.save_manager.save_path)
             self.save_manager.cleanup()
@@ -85,6 +86,7 @@ class Game:
             self.stop,
             self._update_world,
             self.io,
+            log=log_data,
         )
         self.running = True
 
@@ -135,7 +137,11 @@ class Game:
         except (EOFError, KeyboardInterrupt):
             self.io.output(self.language_manager.messages["farewell"])
         finally:
-            self.save_manager.save(self.world, self.language_manager.language)
+            self.save_manager.save(
+                self.world,
+                self.language_manager.language,
+                self.command_processor.log,
+            )
 
 
 def run(

--- a/engine/language.py
+++ b/engine/language.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from . import world
-from .persistence import SaveManager
+from .persistence import LogEntry, SaveManager
 from .interfaces import IOBackend
 from . import i18n
 
@@ -22,7 +22,13 @@ class LanguageManager:
         self.commands = i18n.load_commands(language, io)
         self.command_info = i18n.load_command_info(io)
 
-    def switch(self, language: str, current_world: world.World, save_manager: SaveManager) -> world.World:
+    def switch(
+        self,
+        language: str,
+        current_world: world.World,
+        save_manager: SaveManager,
+        log: list[LogEntry],
+    ) -> world.World:
         """Switch the game to a different language.
 
         Returns the reloaded world instance.  Raises ``ValueError`` if the
@@ -38,7 +44,7 @@ class LanguageManager:
         except FileNotFoundError as exc:  # pragma: no cover - defensive programming
             raise ValueError("Unknown language") from exc
 
-        save_manager.save(current_world, self.language)
+        save_manager.save(current_world, self.language, log)
         new_world.load_state(save_manager.save_path)
         save_manager.cleanup()
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,23 @@
+from engine import game
+
+
+def test_log_records_state_changes_and_show_log(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
+    g.command_processor.execute("look")
+    assert g.command_processor.log == []
+    g.command_processor.execute("go room 2")
+    g.command_processor.execute("take gem")
+    assert [e.command for e in g.command_processor.log] == ["go room 2", "take gem"]
+    g.command_processor.execute("show_log 1")
+    assert io_backend.outputs[-1].splitlines()[0] == "> take gem"
+
+
+def test_log_persisted_in_savegame(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io_backend)
+    g.command_processor.execute("go room 2")
+    g.save_manager.save(
+        g.world, g.language_manager.language, g.command_processor.log
+    )
+    io2 = io_backend.__class__()
+    g2 = game.Game(str(data_dir / "en" / "world.yaml"), "en", io_backend=io2)
+    assert [e.command for e in g2.command_processor.log] == ["go room 2"]


### PR DESCRIPTION
## Summary
- log all state-changing commands and outputs via `LogEntry`
- persist and restore logs in save file and expose `show_log` command
- add tests for logging and log persistence

## Testing
- `ruff engine tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1d5826fb083308162690b3b06cee9