### PR TITLE
Fix pyright return errors and clean commands import

### DIFF
--- a/engine/commands.py
+++ b/engine/commands.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from functools import wraps
 from typing import Callable, cast
 
-from . import io, world
+from . import world
 from .language import LanguageManager
 from .persistence import LogEntry, SaveManager
 from .world_model import StateTag

--- a/engine/interfaces.py
+++ b/engine/interfaces.py
@@ -11,9 +11,11 @@ class IOBackend(Protocol):
 
     def get_input(self, prompt: str = "> ") -> str:  # pragma: no cover - interface
         """Return user input for the given prompt."""
+        ...
 
     def output(self, text: str) -> None:  # pragma: no cover - interface
         """Display ``text`` to the user."""
+        ...
 
 
 @runtime_checkable
@@ -22,6 +24,7 @@ class LLMBackend(Protocol):
 
     def interpret(self, command: str) -> str:  # pragma: no cover - interface
         """Return a normalized version of ``command``."""
+        ...
 
 
 __all__ = ["IOBackend", "LLMBackend"]


### PR DESCRIPTION
## Summary
- add protocol stubs with ellipsis for IOBackend and LLMBackend
- drop unused `io` import to satisfy ruff

## Testing
- `ruff . -v`
- `pyright`
- `pytest --cov --cov-branch -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1f58ab6d88330b004204a54c9c50a