### PR TITLE
State-aware NPC descriptions and meeting logic

### DIFF
--- a/data/de/world.yaml
+++ b/data/de/world.yaml
@@ -61,8 +61,10 @@ npcs:
       text: "Ein Dorfbewohner namens Marek tritt näher und schaut dich eindringlich an."
     states:
       met:
+        text: "Marek wartet hoffnungsvoll auf deine Rückkehr."
         talk: "'Bring die Aschenkrone ins Dorf', sagt Marek. 'Im Wald lebt der Einsiedler Ashram, er kann dir helfen.'"
       helped:
+        text: "Marek begrüßt dich dankbar für deine Hilfe."
         talk: "Marek nickt dir zu. 'Vergiss die Krone nicht.'"
   ashram:
     names:
@@ -71,8 +73,10 @@ npcs:
       text: "Ashram tritt aus den Schatten und bietet seine Hilfe an."
     states:
       met:
+        text: "Ashram sieht dich ruhig an."
         talk: "Ashram hört sich dein Anliegen an und sagt seine Hilfe zu. Er könnte dir helfen, Schriftstücke zu entziffern."
       helped:
+        text: "Ashram nickt nachdenklich, bereit zu helfen."
         talk: "Ashram nickt dir zu und sagt: 'Zeige mir etwas, bei dem ich dir helfen soll.'"
 
 actions:

--- a/data/en/world.yaml
+++ b/data/en/world.yaml
@@ -61,8 +61,10 @@ npcs:
       text: "A villager named Marek approaches you with a wary look."
     states:
       met:
+        text: "Marek waits for your return, hope in his eyes."
         talk: "'Bring the Ashen Crown to the village,' Marek urges. 'Seek the hermit Ashram in the forest; he will aid you.'"
       helped:
+        text: "Marek greets you warmly, grateful for your aid."
         talk: "Marek nods. 'Don't forget the crown.'"
   ashram:
     names:
@@ -71,8 +73,10 @@ npcs:
       text: "Ashram steps from the shadows and offers his help."
     states:
       met:
+        text: "Ashram watches you calmly."
         talk: "Ashram listens to your plight and offers his aid. He can help decipher writings."
       helped:
+        text: "Ashram nods thoughtfully, ready to assist."
         talk: "Ashram nods and says: 'Show me something you'd like help with.'"
 
 actions:

--- a/engine/game.py
+++ b/engine/game.py
@@ -110,17 +110,22 @@ class Game:
         for npc_id, npc in self.world.npcs.items():
             meet = npc.get("meet", {})
             loc = meet.get("location")
-            text = meet.get("text")
             pre = meet.get("preconditions")
-            if (
-                loc == self.world.current
-                and self.world.npc_state(npc_id) != StateTag.MET
-            ):
-                if pre and not self.world.check_preconditions(pre):
-                    continue
+            if loc != self.world.current:
+                continue
+            state = self.world.npc_state(npc_id)
+            if pre and not self.world.check_preconditions(pre):
+                continue
+            if state == "unknown":
+                text = meet.get("text")
                 if text:
                     self.io.output(text)
                 self.world.meet_npc(npc_id)
+            else:
+                state_key = state.value if isinstance(state, StateTag) else state
+                text = npc.get("states", {}).get(state_key, {}).get("text")
+                if text:
+                    self.io.output(text)
 
     def run(self) -> None:
         if self._show_intro and self.world.intro:

--- a/engine/world.py
+++ b/engine/world.py
@@ -573,9 +573,12 @@ class World:
         return True
 
     def meet_npc(self, npc_id: str) -> bool:
-        """Mark an NPC as met if a corresponding state exists."""
+        """Mark an NPC as met only if it was unknown."""
         npc = self.npcs.get(npc_id)
         if not npc:
+            return False
+        state = self.npc_states.get(npc_id)
+        if state != "unknown":
             return False
         states = npc.states
         if StateTag.MET.value not in states:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,10 +103,12 @@ def data_dir(tmp_path):
                 "meet": {"text": "The old man greets you."},
                 "states": {
                     "met": {
-                        "talk": "You tell the old man about your quest. He agrees to help."
+                        "text": "The old man nods at you.",
+                        "talk": "You tell the old man about your quest. He agrees to help.",
                     },
                     "helped": {
-                        "talk": "The old man has already offered his aid."
+                        "text": "The old man smiles at you.",
+                        "talk": "The old man has already offered his aid.",
                     },
                 },
             }
@@ -146,10 +148,12 @@ def data_dir(tmp_path):
                 "meet": {"text": "Der alte Mann grüßt dich."},
                 "states": {
                     "met": {
-                        "talk": "Du erzählst dem alten Mann von deiner Suche. Er hilft dir."
+                        "text": "Der alte Mann nickt dir zu.",
+                        "talk": "Du erzählst dem alten Mann von deiner Suche. Er hilft dir.",
                     },
                     "helped": {
-                        "talk": "Der alte Mann hat dir bereits geholfen."
+                        "text": "Der alte Mann lächelt dich an.",
+                        "talk": "Der alte Mann hat dir bereits geholfen.",
                     },
                 },
             }

--- a/tests/test_npcs.py
+++ b/tests/test_npcs.py
@@ -25,6 +25,13 @@ def test_meet_npc_changes_state():
     assert w.npc_state("old_man") == StateTag.MET
 
 
+def test_meet_npc_ignores_other_states():
+    w = make_world()
+    w.set_npc_state("old_man", StateTag.HELPED)
+    assert not w.meet_npc("old_man")
+    assert w.npc_state("old_man") == StateTag.HELPED
+
+
 def test_set_npc_state_changes_state():
     w = make_world()
     assert w.set_npc_state("old_man", StateTag.HELPED)
@@ -55,6 +62,7 @@ def test_npc_event_triggered_on_room_change(data_dir, capsys):
     g.command_processor.cmd_go("Room 2")
     out = capsys.readouterr().out
     assert "The old man greets you." not in out
+    assert "The old man nods at you." in out
 
 
 def test_npc_event_triggered_on_start(tmp_path, monkeypatch, io_backend):


### PR DESCRIPTION
## Summary
- Show NPC descriptions depending on their current state
- Avoid overwriting non-unknown NPC states when meeting
- Cover NPC states with tests

## Testing
- `ruff .`
- `pyright`
- `pytest --cov --cov-branch -q`


------
https://chatgpt.com/codex/tasks/task_e_68b207358e54833084bbc99720bced7a