### PR TITLE
feat(content): richer atmospheric world texts (DE/EN)

### DIFF
--- a/data/de/world.yaml
+++ b/data/de/world.yaml
@@ -1,10 +1,10 @@
-intro: "Du erwachst in einer kleinen Hütte, draußen liegt die Welt unter Asche."
+intro: "Du erwachst im fahlen Grau eines Morgens, an dem selbst die Stille wie Staub wirkt. Feine Asche rieselt in träge Wirbeln durch Ritzen im Holz, malt milchige Schlieren in das Licht und legt sich wie Erinnerung auf alles, was einmal war. Der Geruch von kaltem Rauch hängt in der Luft. Etwas in dir weiß: Heute wird sich ein altes Versprechen regen, und irgendwo unter all dem Grau wartet eine Krone darauf, die Welt wieder atmen zu lassen."
 items:
   small_key:
     names:
       - Kleiner Schlüssel
       - Schlüssel
-    description: "Ein kleiner, leicht angelaufener Messingschlüssel."
+    description: "Ein kleiner Messingschlüssel, dessen Schaft stumpf vom Anlaufen ist. Seine Zähnung wirkt unauffällig, doch in der Wärme des Metalls liegt der Abdruck vieler Hände. Wenn du ihn zwischen den Fingern drehst, bleibt ein Hauch von Harz und altem Holz in der Luft."
   map_fragment:
     names:
       - Kartenfragment
@@ -12,45 +12,45 @@ items:
       - Karte
     states:
       unreadable:
-        description: "Ein zerknittertes Kartenfragment, dessen Markierungen verwischt sind."
+        description: "Ein zerknittertes, von Nässe welliges Fragment, überzogen mit Ruß und Asche. Wo einst Tinte Linien zog, stehen nur verwaschene Schatten, als hätte jemand Tränen über die Karte vergossen. Jede Berührung hebt grauen Staub."
       readable:
-        description: "Das Fragment zeigt einen Weg von der Hütte zu den Ruinen."
+        description: "Unter dem Schmutz tritt eine dünne, in roter Kohle gezogene Linie hervor: ein Pfad von der Hütte zu den Ruinen. Kleine Randnotizen flüstern von Umwegen und Zeichen. Am Rand ist eingeritzt: 'Folge der Asche, wo der Wind ruht.'"
   ashen_crown:
     names:
       - Aschenkrone
       - Krone
-    description: "Eine von Asche verdunkelte Krone."
+    description: "Eine Krone, von Asche geschwärzt, in deren filigranen Ranken das Grau wie ein Schleier hängt. Sie ist schwerer, als Metall allein es sein dürfte, und in der Kälte ihres Glanzes liegt ein fernes Raunen, als trüge sie die Erinnerung an Stimmen."
   locked_chest:
     names:
       - Verschlossene Truhe
       - Truhe
     states:
       closed:
-        description: "Eine stabile Truhe, leider verschlossen. Du musst den richtigen Schlüssel benutzen, um sie zu öffnen."
+        description: "Eine niedrige Truhe aus dunkel verfärbtem Holz, mit einem einfachen Eisenband gefasst. Feine Asche sammelt sich in der Spalte des Deckels, und irgendwo darin haftet der Geruch von Harz und Regen. Das Schloss wirkt schlicht, aber unbeugsam."
       open:
-        description: "Die Truhe steht offen und zeigt ihren Inhalt. Sie ist voller Asche, und darin eine Krone."
+        description: "Der Deckel gibt mit einem müden Seufzen nach. Alte Luft entweicht, staubig und süßlich. Innen ist der Samt zu Pulver zerfallen; in der Asche ruht etwas, das wie Schlaf wirkt: eine Krone, stumpf schimmernd."
 
 rooms:
   hut:
     names:
       - Hütte
       - Häuschen
-    description: "Eine schlichte Hütte mit knarrendem Dach."
+    description: "Eine schlichte Hütte, deren Dach in jedem Windstoß leise klagt. Das Licht fällt durch schmale Fugen, tanzt in feinen Staubfahnen. Der Boden ist rau, unter deinen Stiefeln knirscht Asche. Eine kalte Feuerstelle riecht nach längst verglühter Glut."
   forest:
     names:
       - Wald
       - Forst
-    description: "Ein lichter Wald, dessen Bäume von Asche bedeckt sind."
+    description: "Ein lichter Wald, dessen Nadeln und Blätter einen grauen Flaum tragen. Jeder Schritt wirbelt einen flachen Atem von Staub auf. Fern ruft eine Krähe, und die Sonne hängt blass wie eine Münze zwischen den Zweigen."
   ruins:
     names:
       - Ruinen
       - Ruinenstätte
-    description: "Bröckelnde Steine zeugen von vergangener Zeit."
+    description: "Zerfallene Bögen und geborstene Stufen, über denen der Wind wie durch Flötenlöcher pfeift. In Ecken türmt sich Asche zu stillen Dünen; unter der grauen Haut blitzt hier und da ein Mosaik auf. Die Steine tragen Brandmale aus einer Zeit, die niemand mehr exakt benennen kann."
   ash_village:
     names:
       - Aschendorf
       - Dorf
-    description: "Ein Dorf, das unter einer Schicht Asche liegt."
+    description: "Ein Dorf, geduckt unter der weichen Last der Asche. Dächer biegen sich, Türen stehen einen Spalt offen, als lauschten sie. Im Brunnen liegt das Wasser dunkel und unbewegt. Alte Wimpel hängen in Fäden; der Geruch von Ruß und getrockneten Kräutern liegt darüber."
 
 npcs:
   villager:
@@ -58,37 +58,37 @@ npcs:
       - Marek
       - Dorfbewohner
     meet:
-      text: "Ein Dorfbewohner namens Marek tritt näher und schaut dich eindringlich an."
+      text: "Aus einem Schleier herabrieselnder Asche tritt ein Mann hervor. Seine Augen glimmen wie verkohlte Funken, die nicht ganz erloschen sind. 'Marek', stellt er sich mit rauer Stimme vor."
     states:
       met:
-        text: "Marek wartet hoffnungsvoll auf deine Rückkehr."
-        talk: "'Bring die Aschenkrone ins Dorf', sagt Marek. 'Im Wald lebt der Einsiedler Ashram, er kann dir helfen.'"
+        text: "Marek wartet, den Blick immer wieder zum Horizont gerichtet, wo der Wind die Asche in Wellen treibt."
+        talk: "'Bring die Aschenkrone ins Dorf', sagt Marek leise, als wolle er die Asche nicht wecken. 'Im Wald lebt der Einsiedler Ashram – er liest Spuren, wo andere nur Staub sehen. Er wird dir helfen.'"
       helped:
-        text: "Marek begrüßt dich dankbar für deine Hilfe."
-        talk: "Marek nickt dir zu. 'Vergiss die Krone nicht.'"
+        text: "Marek begrüßt dich mit einem echten Lächeln, das in dieser grauen Welt selten ist."
+        talk: "Marek nickt. 'Vergiss die Krone nicht. Jeder Schritt mit ihr lässt die Asche ein wenig leichter fallen.'"
   ashram:
     names:
       - Ashram
     meet:
-      text: "Ashram tritt aus den Schatten und bietet seine Hilfe an."
+      text: "Zwischen knorrigen Stämmen löst sich eine Gestalt aus dem Schatten. Ein Hauch von Kräutern liegt um ihn, und sein Blick ist ruhig wie stilles Wasser. 'Ashram', sagt er. 'Wenn du Antworten suchst, zeig mir, was die Asche verbirgt.'"
     states:
       met:
-        text: "Ashram sieht dich ruhig an."
-        talk: "Ashram hört sich dein Anliegen an und sagt seine Hilfe zu. Er könnte dir helfen, Schriftstücke zu entziffern."
+        text: "Ashram mustert dich, als lese er das Wetter in deinem Gesicht."
+        talk: "Er hört dir zu, ohne zu unterbrechen, und seine fingerlangen Kreidespuren verraten einen, der Zeichen zu lesen weiß. 'Bringe mir, was du nicht entziffern kannst', sagt er. 'Die Asche schreibt in feinen Linien.'"
       helped:
-        text: "Ashram nickt nachdenklich, bereit zu helfen."
-        talk: "Ashram nickt dir zu und sagt: 'Zeige mir etwas, bei dem ich dir helfen soll.'"
+        text: "Ashram nickt, in seinen Augen glimmt es, als hätte jemand eine Glut geschürt."
+        talk: "'Zeig mir, was der Staub verschluckt hat', sagt er. 'Gemeinsam holen wir die Schrift wieder an die Oberfläche.'"
 
 actions:
   open_chest:
     messages:
-      success: "Der Schlüssel klickt, und die Truhe entriegelt sich."
+      success: "Der Schlüssel beißt in das Schloss, ein müdes Klicken, dann gibt das Eisen nach. Der Deckel antwortet mit einem langen, hölzernen Stöhnen."
   interpret_map:
     messages:
-      success: "Ashram hilft dir, die verblasste Karte zu entziffern. Damit kannst du jetzt deinen Weg finden."
+      success: "Ashram wischt den Staub mit der flachen Hand fort, murmelt alte Ortsnamen. Nach und nach hebt sich ein Weg ab, wie eine Narbe, die das Licht wiederfindet."
   find_crown:
     messages:
-      success: "Eine Krone ist darin, halb verdeckt von einer Schicht Asche. Du nimmst sie an dich."
+      success: "Im Pulver des zerfallenen Samts liegt eine Krone, stumpf und würdevoll. Als du sie an dich nimmst, hinterlässt sie dunkle Spuren auf deinen Händen – als Zeichen, das bleibt."
 
 endings:
-  crown_returned: "Mit der Aschenkrone kehrst du ins Dorf zurück und erfüllst dein Schicksal."
+  crown_returned: "Mit der Aschenkrone kehrst du ins Dorf zurück. Die Menschen treten aus den Türrahmen, und die Asche fällt plötzlich wie langsamer Schnee. In deinen Schritten wird der Weg klarer, als bliese ein unsichtbarer Wind die Welt frei. Man nennt deinen Namen, und zum ersten Mal seit langem klingt er nicht wie ein Echo im Staub."

--- a/data/en/world.yaml
+++ b/data/en/world.yaml
@@ -1,10 +1,10 @@
-intro: "You wake in a small hut, the world outside shrouded in ash."
+intro: "You wake to a pallid grey morning, where even silence feels like dust. Fine ash drifts through seams in the wood, sketching pale currents in the light and settling like memory on everything that remains. Cold smoke lingers in the air. Something in you knows: an old promise will stir today, and somewhere beneath the grey a crown waits for the world to breathe again."
 items:
   small_key:
     names:
       - Small Key
       - Key
-    description: "A small brass key, slightly tarnished."
+    description: "A small brass key, its shaft dulled with age. The teeth look ordinary, yet the metal holds the warmth of many hands. Turn it between your fingers and a hint of resin and old wood lingers."
   map_fragment:
     names:
       - Map Fragment
@@ -12,45 +12,45 @@ items:
       - Map
     states:
       unreadable:
-        description: "A torn fragment of a map with smudged markings."
+        description: "A torn, water-warped scrap veiled in soot and ash. Where ink once traced lines, only blurred ghosts remain, as if tears had run across the page. Every touch lifts a grey breath."
       readable:
-        description: "The fragment reveals a route from the hut to the ruins."
+        description: "Beneath the grime a thin line in red charcoal emerges: a path from the hut to the ruins. Small notes whisper of detours and signs. At the edge, a shallow cut reads: 'Follow the ash where the wind rests.'"
   ashen_crown:
     names:
       - Ashen Crown
       - Crown
-    description: "A crown darkened by ash."
+    description: "A crown blackened by ash, its filigree heavy with grey. It weighs more than metal should, and in its cold sheen there is the faintest murmur, as if it remembered voices."
   locked_chest:
     names:
       - Locked Chest
       - Chest
     states:
       closed:
-        description: "A sturdy chest secured by a simple lock."
+        description: "A low chest of darkened wood banded with plain iron. Fine ash gathers along the lid's seam, and somewhere within clings the scent of resin and rain. The lock is simple, yet stubborn."
       open:
-        description: "The chest stands open, its contents revealed."
+        description: "The lid yields with a tired sigh. Stale air spills out, dusty and sweet. Inside, the velvet has powdered away; in the ash something rests as if asleep: a crown, dimly gleaming."
 
 rooms:
   hut:
     names:
       - Hut
       - Cabin
-    description: "A modest hut with a creaking roof."
+    description: "A modest hut whose roof complains at every gust. Light slips through thin seams and dances in slow dust. The floor is rough; ash grits beneath your boots. A cold hearth smells of long-spent embers."
   forest:
     names:
       - Forest
       - Woods
-    description: "A sparse forest, its trees coated in ash."
+    description: "Open woods laid with a soft grey bloom. Each step breathes up a shallow drift. A crow calls far off, and the sun hangs pale as a coin between the branches."
   ruins:
     names:
       - Ruins
       - Ruined Site
-    description: "Crumbling stones hint at forgotten times."
+    description: "Broken arches and split stairs where the wind plays like a flute. Ash piles into quiet dunes; beneath the grey skin a mosaic shows in fragments. The stones wear scorch marks from a time no one can name."
   ash_village:
     names:
       - Ash Village
       - Village
-    description: "A village blanketed in ash."
+    description: "A village bowed beneath a soft weight of ash. Roofs sag; doors stand ajar as if listening. Water lies dark and still in the well. Old pennants hang in threads; soot and dried herbs scent the air."
 
 npcs:
   villager:
@@ -58,37 +58,37 @@ npcs:
       - Marek
       - Villager
     meet:
-      text: "A villager named Marek approaches you with a wary look."
+      text: "A figure steps from a fall of drifting ash. His eyes glow like not-quite-dead coals. 'Marek,' he says in a voice roughened by smoke."
     states:
       met:
-        text: "Marek waits for your return, hope in his eyes."
-        talk: "'Bring the Ashen Crown to the village,' Marek urges. 'Seek the hermit Ashram in the forest; he will aid you.'"
+        text: "Marek waits, his gaze straying to the horizon where the wind combs ash into waves."
+        talk: "'Bring the Ashen Crown to the village,' Marek says softly, as if not to wake the dust. 'In the forest lives Ashram the hermit—he reads signs where others see only soot. He will help you.'"
       helped:
-        text: "Marek greets you warmly, grateful for your aid."
-        talk: "Marek nods. 'Don't forget the crown.'"
+        text: "Marek greets you with a rare, unguarded smile."
+        talk: "Marek nods. 'Don't forget the crown. Each step with it makes the ash fall a little lighter.'"
   ashram:
     names:
       - Ashram
     meet:
-      text: "Ashram steps from the shadows and offers his help."
+      text: "A shape loosens from the trees' shadow. A breath of herbs clings to him, and his gaze is still as water. 'Ashram,' he says. 'If you seek answers, show me what the ash has hidden.'"
     states:
       met:
-        text: "Ashram watches you calmly."
-        talk: "Ashram listens to your plight and offers his aid. He can help decipher writings."
+        text: "Ashram studies you as if reading the weather from your face."
+        talk: "He listens without interruption; chalk-dusted fingers betray a reader of signs. 'Bring me what you cannot decipher,' he says. 'Ash writes in fine lines.'"
       helped:
-        text: "Ashram nods thoughtfully, ready to assist."
-        talk: "Ashram nods and says: 'Show me something you'd like help with.'"
+        text: "Ashram nods; a spark glows in his eyes as if a coal were stirred."
+        talk: "'Show me what the dust has swallowed,' he says. 'Together we'll draw the words back to the surface.'"
 
 actions:
   open_chest:
     messages:
-      success: "The key turns with a click and the chest unlocks."
+      success: "The key bites; a tired click, and the iron yields. The lid answers with a long wooden groan."
   interpret_map:
     messages:
-      success: "Ashram helps you decipher the faded map. You can now find your way."
+      success: "Ashram brushes the dust away, murmuring old place-names. Slowly a path rises, like a scar finding the light again."
   find_crown:
     messages:
-      success: "Half buried in ash, a crown glints. You take it with you."
+      success: "In the powder of perished velvet rests a crown, dim and grave. When you take it up, it stains your hands—marks that linger."
 
 endings:
-  crown_returned: "With the Ashen Crown reclaimed, you return to the village as its destined ruler."
+  crown_returned: "With the Ashen Crown returned, you walk back into the village. People step from their doorframes, and ash begins to fall like slow snow. In your footprints the way grows clearer, as if an unseen wind were sweeping the world. Your name is spoken, and for the first time in a long while it does not sound like an echo in the dust."


### PR DESCRIPTION
This PR enriches the in-game narrative across DE/EN:\n\n- Expanded intro with atmospheric tone\n- Richer room descriptions (hut, forest, ruins, village)\n- Deeper item texts incl. state-specific descriptions\n- More evocative NPC lines (Marek, Ashram)\n- Polished action messages and ending text\n\nAll tests pass locally (69/69).