### PR TITLE
chore(packaging): include game package; docs: module run commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,10 @@
 - Tests schnell: `poetry run pytest -q`
 - Tests mit Coverage: `poetry run pytest --cov --cov-branch -q`
 - Abhängigkeiten: `poetry add <pkg>`; Dev-Tools: `poetry add --group dev ruff pyright pytest pytest-cov`
- - Ausführen (Beispiel): `poetry run herrschaft-der-asche --language de`
+ - Ausführen:
+   - Entry-Point: `poetry run herrschaft-der-asche --language de`
+   - Modulstart: `poetry run python -m game.main --language de`
+   - Notfall (Dateiaufruf): `poetry run PYTHONPATH=. python game/main.py --language de`
 
 ## Coding Style & Benennung
 - Stil: PEP8, geprüft via ruff; Typen via pyright

--- a/game/__init__.py
+++ b/game/__init__.py
@@ -1,0 +1,2 @@
+"""Game entry package for CLI startup."""
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,10 @@ name = "herrschaft-der-asche"
 version = "0.1.0"
 description = "A simple text adventure"
 authors = ["Der Mann mit Hut <dermannmithut@metstuebchen.de>"]
-packages = [{ include = "engine" }]
+packages = [
+  { include = "engine" },
+  { include = "game" }
+]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<4.0"


### PR DESCRIPTION
This PR fixes module import/runtime issues when invoking the game directly.\n\n- Package  included in Poetry config (alongside )\n- Added  to make it an explicit package\n- Docs: AGENTS.md now shows recommended run commands: entry point, module run, and PYTHONPATH workaround\n\nVerified: \n- poetry check/install ok (with deprecation warnings from Poetry schema)\n- Eine schlichte Hütte, deren Dach in jedem Windstoß leise klagt. Das Licht fällt durch schmale Fugen, tanzt in feinen Staubfahnen. Der Boden ist rau, unter deinen Stiefeln knirscht Asche. Eine kalte Feuerstelle riecht nach längst verglühter Glut. Du siehst hier: Kleiner Schlüssel. Ausgänge: Wald.
> Auf Wiedersehen! starts successfully\n- All tests pass (69/69).