### PR TITLE
refactor: remove NPC current location field

### DIFF
--- a/engine/game.py
+++ b/engine/game.py
@@ -44,7 +44,9 @@ class Game:
         lang_world_path = self.data_dir / self._language / "world.yaml"
 
         try:
-            self.world = world.World.from_files(generic_path, lang_world_path, debug=debug)
+            self.world = world.World.from_files(
+                generic_path, lang_world_path, debug=debug
+            )
         except FileNotFoundError as exc:
             self.io.output(f"ERROR: Missing world file: {exc}")
             raise SystemExit from exc
@@ -107,12 +109,13 @@ class Game:
             self.running = False
 
     def _check_npc_event(self) -> None:
-        for npc_id, npc in self.world.npcs.items():
-            meet = npc.get("meet", {})
-            loc = meet.get("location")
-            pre = meet.get("preconditions")
-            if loc != self.world.current:
+        room = self.world.rooms[self.world.current]
+        for npc_id in list(room.occupants):
+            npc = self.world.npcs.get(npc_id)
+            if not npc:
                 continue
+            meet = npc.get("meet", {})
+            pre = meet.get("preconditions")
             state = self.world.npc_state(npc_id)
             if pre and not self.world.check_preconditions(pre):
                 continue
@@ -163,4 +166,3 @@ def run(
         llm_backend=llm_backend,
         debug=debug,
     ).run()
-

--- a/engine/world_model.py
+++ b/engine/world_model.py
@@ -1,5 +1,7 @@
 """Data models for world elements."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List, Optional
@@ -21,6 +23,7 @@ class Room:
     description: str = ""
     items: List[str] = field(default_factory=list)
     exits: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+    occupants: List[str] = field(default_factory=list)
 
     def get(self, key: str, default: Any = None) -> Any:  # pragma: no cover - compat
         return getattr(self, key, default)
@@ -101,4 +104,3 @@ __all__ = [
     "Npc",
     "Action",
 ]
-

--- a/tests/test_npcs.py
+++ b/tests/test_npcs.py
@@ -38,6 +38,14 @@ def test_set_npc_state_changes_state():
     assert w.npc_state("old_man") == StateTag.HELPED
 
 
+def test_add_remove_npc_location():
+    w = make_world()
+    w.add_npc_to_location("old_man", "room1")
+    assert "old_man" in w.rooms["room1"].occupants
+    w.remove_npc_from_location("old_man", "room1")
+    assert "old_man" not in w.rooms["room1"].occupants
+
+
 def test_npc_state_saved_and_loaded(tmp_path):
     w = make_world()
     w.meet_npc("old_man")
@@ -90,7 +98,9 @@ def test_npc_event_triggered_on_start(tmp_path, monkeypatch, io_backend):
         yaml.safe_dump(en, fh)
 
     outputs = io_backend.outputs
-    monkeypatch.setattr(io_backend, "get_input", lambda prompt='> ': (_ for _ in ()).throw(EOFError()))
+    monkeypatch.setattr(
+        io_backend, "get_input", lambda prompt="> ": (_ for _ in ()).throw(EOFError())
+    )
 
     g = game.Game(str(tmp_path / "en" / "world.yaml"), "en", io_backend=io_backend)
     g.run()

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -7,10 +7,12 @@ def test_room_dataclass():
         description="Desc",
         items=["key"],
         exits={"north": {"names": ["North"]}},
+        occupants=["npc"],
     )
     assert room.names[0] == "Hall"
     assert room.items == ["key"]
     assert "north" in room.exits
+    assert room.occupants == ["npc"]
 
 
 def test_item_dataclass():
@@ -44,4 +46,3 @@ def test_action_dataclass():
     assert action.trigger == "use"
     assert action.item == "key"
     assert action.messages["success"] == "opened"
-


### PR DESCRIPTION
## Summary
- drop `current_location` from `Npc` data model
- rely on room occupants for NPC placement and movement
- adjust tests for new location handling

## Testing
- `poetry run ruff check engine/world_model.py engine/world.py tests/test_world_model.py tests/test_npcs.py`
- `poetry run pyright engine/world_model.py engine/world.py tests/test_world_model.py tests/test_npcs.py`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b2a94dd2f88330a325406e1071dca1