### PR TITLE
refactor: unify condition lists

### DIFF
--- a/data/generic/world.yaml
+++ b/data/generic/world.yaml
@@ -61,15 +61,15 @@ actions:
     item: map_fragment
     target_npc: ashram
     preconditions:
-      npc_condition:
-        - npc: ashram
-          state: helped
+      - npc_conditions:
+          - npc: ashram
+            state: helped
     effect:
-      item_condition:
-        - item: map_fragment
-          state: readable
-      add_exit:
-        - room: hut
+      - item_conditions:
+          - item: map_fragment
+            state: readable
+      - add_exit:
+          room: hut
           target: ruins
 
   open_chest:
@@ -77,30 +77,30 @@ actions:
     item: small_key
     target_item: locked_chest
     preconditions:
-      is_location: ruins
+      - is_location: ruins
     effect:
-      item_condition:
-        - item: locked_chest
-          state: open
+      - item_conditions:
+          - item: locked_chest
+            state: open
 
   find_crown:
     trigger: examine
     item: locked_chest
-    precondition:
-      item_condition:
-        item: locked_chest
-        state: open
+    preconditions:
+      - item_conditions:
+          - item: locked_chest
+            state: open
     effect:
-      item_condition:
-        - item: ashen_crown
-          location: INVENTORY
+      - item_conditions:
+          - item: ashen_crown
+            location: INVENTORY
 
 start: hut
 
 endings:
   crown_returned:
     preconditions:
-      is_location: ash_village
-      item_condition:
-        item: ashen_crown
-        location: INVENTORY
+      - is_location: ash_village
+      - item_conditions:
+          - item: ashen_crown
+            location: INVENTORY

--- a/engine/integrity.py
+++ b/engine/integrity.py
@@ -76,14 +76,10 @@ def check_translations(language: str, data_dir: Path) -> List[str]:
         lang_actions = lang_world.get("actions", {})
         for action_id in base_actions:
             if action_id not in lang_actions:
-                warnings.append(
-                    f"Missing translation for action '{action_id}'"
-                )
+                warnings.append(f"Missing translation for action '{action_id}'")
         for action_id in lang_actions:
             if action_id not in base_actions:
-                warnings.append(
-                    f"Translation for unused action '{action_id}' ignored"
-                )
+                warnings.append(f"Translation for unused action '{action_id}' ignored")
 
     return warnings
 
@@ -98,14 +94,10 @@ def validate_world_structure(w: world.World) -> List[str]:
         exits = room.get("exits", {})
         for target in exits:
             if target not in w.rooms:
-                errors.append(
-                    f"Room '{room_id}' has exit to missing room '{target}'"
-                )
+                errors.append(f"Room '{room_id}' has exit to missing room '{target}'")
         for item in room.get("items", []):
             if item not in w.items:
-                errors.append(
-                    f"Room '{room_id}' contains missing item '{item}'"
-                )
+                errors.append(f"Room '{room_id}' contains missing item '{item}'")
 
     # Start room -------------------------------------------------------------
     if w.current not in w.rooms:
@@ -123,103 +115,166 @@ def validate_world_structure(w: world.World) -> List[str]:
             errors.append(f"Action references missing item '{item}'")
         target_item = action.get("target_item")
         if target_item and target_item not in w.items:
-            errors.append(
-                f"Action references missing target item '{target_item}'"
-            )
-        pre = action.get("preconditions", {})
-        loc = pre.get("is_location")
-        if loc and loc not in w.rooms:
-            errors.append(
-                f"Action precondition references missing room '{loc}'"
-            )
-        cond = pre.get("item_condition", {})
-        cond_item = cond.get("item")
-        if cond_item and cond_item not in w.items:
-            errors.append(
-                f"Action precondition references missing item '{cond_item}'"
-            )
-        cond_loc = cond.get("location")
-        if cond_loc:
-            if isinstance(cond_loc, LocationTag):
-                if cond_loc is not LocationTag.INVENTORY and cond_loc.value not in w.rooms:
+            errors.append(f"Action references missing target item '{target_item}'")
+        pre_list = action.get("preconditions") or []
+        if isinstance(pre_list, dict):
+            pre_list = [pre_list]
+        for pre in pre_list:
+            loc = pre.get("is_location")
+            if loc and loc not in w.rooms:
+                errors.append(f"Action precondition references missing room '{loc}'")
+            conds = pre.get("item_conditions") or pre.get("item_condition") or []
+            if isinstance(conds, dict):
+                conds = [conds]
+            for cond in conds:
+                cond_item = cond.get("item")
+                if cond_item and cond_item not in w.items:
                     errors.append(
-                        f"Action precondition references missing location '{cond_loc.value}'"
+                        f"Action precondition references missing item '{cond_item}'"
                     )
-            elif cond_loc not in w.rooms:
-                errors.append(
-                    f"Action precondition references missing location '{cond_loc}'"
-                )
-        eff = action.get("effect", {}).get("item_condition", [])
-        if isinstance(eff, dict):
-            eff = [eff]
-        for cond in eff:
-            eff_item = cond.get("item")
-            if eff_item and eff_item not in w.items:
-                errors.append(
-                    f"Action effect references missing item '{eff_item}'"
-                )
-            eff_state = cond.get("state")
-            if eff_item and eff_state and eff_state not in w.items.get(eff_item, {}).get("states", {}):
-                errors.append(
-                    f"Action effect references missing state '{eff_state}' for item '{eff_item}'"
-                )
-            eff_loc = cond.get("location")
-            if eff_loc:
-                if isinstance(eff_loc, LocationTag):
-                    if eff_loc is not LocationTag.INVENTORY and eff_loc.value not in w.rooms:
+                cond_loc = cond.get("location")
+                if cond_loc:
+                    if isinstance(cond_loc, LocationTag):
+                        if (
+                            cond_loc is not LocationTag.INVENTORY
+                            and cond_loc.value not in w.rooms
+                        ):
+                            errors.append(
+                                f"Action precondition references missing location '{cond_loc.value}'"
+                            )
+                    elif cond_loc not in w.rooms:
                         errors.append(
-                            f"Action effect references missing location '{eff_loc.value}'"
+                            f"Action precondition references missing location '{cond_loc}'"
                         )
-                elif eff_loc not in w.rooms:
+            npc_conds = pre.get("npc_conditions") or pre.get("npc_condition") or []
+            if isinstance(npc_conds, dict):
+                npc_conds = [npc_conds]
+            for cond in npc_conds:
+                cond_npc = cond.get("npc")
+                if cond_npc and cond_npc not in w.npcs:
                     errors.append(
-                        f"Action effect references missing location '{eff_loc}'"
+                        f"Action precondition references missing NPC '{cond_npc}'"
                     )
+                cond_state = cond.get("state")
+                if cond_npc and cond_state:
+                    state_key = (
+                        cond_state.value
+                        if isinstance(cond_state, StateTag)
+                        else cond_state
+                    )
+                    if state_key not in w.npcs.get(cond_npc, {}).get("states", {}):
+                        errors.append(
+                            f"Action precondition references missing state '{state_key}' for NPC '{cond_npc}'"
+                        )
+        eff_list = action.get("effect") or []
+        if isinstance(eff_list, dict):
+            eff_list = [eff_list]
+        for eff in eff_list:
+            conds = eff.get("item_conditions") or eff.get("item_condition") or []
+            if isinstance(conds, dict):
+                conds = [conds]
+            for cond in conds:
+                eff_item = cond.get("item")
+                if eff_item and eff_item not in w.items:
+                    errors.append(f"Action effect references missing item '{eff_item}'")
+                eff_state = cond.get("state")
+                if (
+                    eff_item
+                    and eff_state
+                    and eff_state not in w.items.get(eff_item, {}).get("states", {})
+                ):
+                    errors.append(
+                        f"Action effect references missing state '{eff_state}' for item '{eff_item}'"
+                    )
+                eff_loc = cond.get("location")
+                if eff_loc:
+                    if isinstance(eff_loc, LocationTag):
+                        if (
+                            eff_loc is not LocationTag.INVENTORY
+                            and eff_loc.value not in w.rooms
+                        ):
+                            errors.append(
+                                f"Action effect references missing location '{eff_loc.value}'"
+                            )
+                    elif eff_loc not in w.rooms:
+                        errors.append(
+                            f"Action effect references missing location '{eff_loc}'"
+                        )
 
     # NPCs -------------------------------------------------------------------
     for npc_id, npc in w.npcs.items():
         meet = npc.get("meet", {})
         loc = meet.get("location")
         if loc and loc not in w.rooms:
-            errors.append(
-                f"NPC '{npc_id}' references missing room '{loc}'"
-            )
+            errors.append(f"NPC '{npc_id}' references missing room '{loc}'")
         state = npc.get("state")
         state_key = state.value if isinstance(state, StateTag) else state
         if state_key and state_key not in npc.get("states", {}):
-            errors.append(
-                f"NPC '{npc_id}' has undefined state '{state_key}'"
-            )
+            errors.append(f"NPC '{npc_id}' has undefined state '{state_key}'")
 
     # Endings ----------------------------------------------------------------
     for end_id, ending in w.endings.items():
-        pre = ending.get("preconditions", {})
-        loc = pre.get("is_location")
-        if loc and loc not in w.rooms:
-            errors.append(
-                f"Ending '{end_id}' precondition references missing room '{loc}'"
-            )
-        cond = pre.get("item_condition", {})
-        cond_item = cond.get("item")
-        if cond_item and cond_item not in w.items:
-            errors.append(
-                f"Ending '{end_id}' references missing item '{cond_item}'"
-            )
-        cond_loc = cond.get("location")
-        if cond_loc:
-            if isinstance(cond_loc, LocationTag):
-                if cond_loc is not LocationTag.INVENTORY and cond_loc.value not in w.rooms:
-                    errors.append(
-                        f"Ending '{end_id}' references missing location '{cond_loc.value}'"
-                    )
-            elif cond_loc not in w.rooms:
+        pre_list = ending.get("preconditions") or []
+        if isinstance(pre_list, dict):
+            pre_list = [pre_list]
+        for pre in pre_list:
+            loc = pre.get("is_location")
+            if loc and loc not in w.rooms:
                 errors.append(
-                    f"Ending '{end_id}' references missing location '{cond_loc}'"
+                    f"Ending '{end_id}' precondition references missing room '{loc}'"
                 )
-        state = cond.get("state")
-        if cond_item and state and state not in w.items.get(cond_item, {}).get("states", {}):
-            errors.append(
-                f"Ending '{end_id}' references missing state '{state}' for item '{cond_item}'"
-            )
+            conds = pre.get("item_conditions") or pre.get("item_condition") or []
+            if isinstance(conds, dict):
+                conds = [conds]
+            for cond in conds:
+                cond_item = cond.get("item")
+                if cond_item and cond_item not in w.items:
+                    errors.append(
+                        f"Ending '{end_id}' references missing item '{cond_item}'"
+                    )
+                cond_loc = cond.get("location")
+                if cond_loc:
+                    if isinstance(cond_loc, LocationTag):
+                        if (
+                            cond_loc is not LocationTag.INVENTORY
+                            and cond_loc.value not in w.rooms
+                        ):
+                            errors.append(
+                                f"Ending '{end_id}' references missing location '{cond_loc.value}'"
+                            )
+                    elif cond_loc not in w.rooms:
+                        errors.append(
+                            f"Ending '{end_id}' references missing location '{cond_loc}'"
+                        )
+                state = cond.get("state")
+                if (
+                    cond_item
+                    and state
+                    and state not in w.items.get(cond_item, {}).get("states", {})
+                ):
+                    errors.append(
+                        f"Ending '{end_id}' references missing state '{state}' for item '{cond_item}'"
+                    )
+            npc_conds = pre.get("npc_conditions") or pre.get("npc_condition") or []
+            if isinstance(npc_conds, dict):
+                npc_conds = [npc_conds]
+            for cond in npc_conds:
+                cond_npc = cond.get("npc")
+                if cond_npc and cond_npc not in w.npcs:
+                    errors.append(
+                        f"Ending '{end_id}' references missing NPC '{cond_npc}'"
+                    )
+                cond_state = cond.get("state")
+                if cond_npc and cond_state:
+                    state_key = (
+                        cond_state.value
+                        if isinstance(cond_state, StateTag)
+                        else cond_state
+                    )
+                    if state_key not in w.npcs.get(cond_npc, {}).get("states", {}):
+                        errors.append(
+                            f"Ending '{end_id}' references missing state '{state_key}' for NPC '{cond_npc}'"
+                        )
 
     return errors
 
@@ -235,15 +290,11 @@ def validate_save(data: Dict[str, Any], w: world.World) -> List[str]:
 
     for item_id in data.get("inventory", []):
         if item_id not in w.items:
-            errors.append(
-                f"Save references missing item '{item_id}' in inventory"
-            )
+            errors.append(f"Save references missing item '{item_id}' in inventory")
 
     for room_id, items in data.get("rooms", {}).items():
         if room_id not in w.rooms:
-            errors.append(
-                f"Save references missing room '{room_id}'"
-            )
+            errors.append(f"Save references missing room '{room_id}'")
         else:
             for item_id in items or []:
                 if item_id not in w.items:
@@ -253,9 +304,7 @@ def validate_save(data: Dict[str, Any], w: world.World) -> List[str]:
 
     for item_id, state in data.get("item_states", {}).items():
         if item_id not in w.items:
-            errors.append(
-                f"Save references missing item '{item_id}' in item_states"
-            )
+            errors.append(f"Save references missing item '{item_id}' in item_states")
         else:
             states = w.items.get(item_id, {}).get("states", {})
             if state not in states:
@@ -265,9 +314,7 @@ def validate_save(data: Dict[str, Any], w: world.World) -> List[str]:
 
     for npc_id, state in data.get("npc_states", {}).items():
         if npc_id not in w.npcs:
-            errors.append(
-                f"Save references missing NPC '{npc_id}' in npc_states"
-            )
+            errors.append(f"Save references missing NPC '{npc_id}' in npc_states")
         else:
             states = w.npcs.get(npc_id, {}).get("states", {})
             if state not in states:

--- a/engine/world.py
+++ b/engine/world.py
@@ -50,13 +50,16 @@ class World:
             actions = list(actions.values())
         normalized: list[Any] = []
         for action in actions:
-            if (
-                isinstance(action, dict)
-                and "precondition" in action
-                and "preconditions" not in action
-            ):
+            if isinstance(action, dict):
                 action = dict(action)
-                action["preconditions"] = action.pop("precondition")
+                if "precondition" in action and "preconditions" not in action:
+                    action["preconditions"] = action.pop("precondition")
+                pre = action.get("preconditions")
+                if isinstance(pre, dict):
+                    action["preconditions"] = [pre]
+                eff = action.get("effect")
+                if isinstance(eff, dict):
+                    action["effect"] = [eff]
             normalized.append(action)
         self.actions = [
             act if isinstance(act, Action) else Action(**act) for act in normalized
@@ -338,35 +341,46 @@ class World:
             return False
         return self.npc_state(npc_id) == state
 
-    def check_preconditions(self, pre: Dict[str, Any] | None) -> bool:
+    def check_preconditions(
+        self, pre: list[Dict[str, Any]] | Dict[str, Any] | None
+    ) -> bool:
         if not pre:
             return True
-        loc = pre.get("is_location")
-        if loc and self.current != (loc.value if isinstance(loc, LocationTag) else loc):
-            return False
-        item_cond = pre.get("item_condition")
-        if item_cond and not self._check_item_condition(item_cond):
-            return False
-        npc_met = pre.get("npc_met")
-        if npc_met and not self._check_npc_condition(
-            {"npc": npc_met, "state": StateTag.MET}
-        ):
-            return False
-        npc_help = pre.get("npc_help")
-        if npc_help and not self._check_npc_condition(
-            {"npc": npc_help, "state": StateTag.HELPED}
-        ):
-            return False
-        npc_cond = pre.get("npc_state")
-        if npc_cond and not self._check_npc_condition(npc_cond):
-            return False
-        npc_conditions = pre.get("npc_condition")
-        if npc_conditions:
-            if isinstance(npc_conditions, dict):
-                npc_conditions = [npc_conditions]
-            for cond in npc_conditions:
-                if not self._check_npc_condition(cond):
-                    return False
+        if isinstance(pre, dict):
+            pre = [pre]
+        for cond in pre:
+            loc = cond.get("is_location")
+            if loc and self.current != (
+                loc.value if isinstance(loc, LocationTag) else loc
+            ):
+                return False
+            item_cond = cond.get("item_conditions") or cond.get("item_condition")
+            if item_cond:
+                if isinstance(item_cond, dict):
+                    item_cond = [item_cond]
+                for ic in item_cond:
+                    if not self._check_item_condition(ic):
+                        return False
+            npc_met = cond.get("npc_met")
+            if npc_met and not self._check_npc_condition(
+                {"npc": npc_met, "state": StateTag.MET}
+            ):
+                return False
+            npc_help = cond.get("npc_help")
+            if npc_help and not self._check_npc_condition(
+                {"npc": npc_help, "state": StateTag.HELPED}
+            ):
+                return False
+            npc_state = cond.get("npc_state")
+            if npc_state and not self._check_npc_condition(npc_state):
+                return False
+            npc_conditions = cond.get("npc_conditions") or cond.get("npc_condition")
+            if npc_conditions:
+                if isinstance(npc_conditions, dict):
+                    npc_conditions = [npc_conditions]
+                for nc in npc_conditions:
+                    if not self._check_npc_condition(nc):
+                        return False
         return True
 
     def apply_item_condition(self, cond: Dict[str, Any]) -> None:
@@ -397,23 +411,30 @@ class World:
                 room.items.append(item_id)
                 self.debug(f"room {room_id} items {room.items}")
 
-    def apply_effect(self, effect: Dict[str, Any]) -> None:
-        item_cond = effect.get("item_condition") or effect.get("item_conditions")
-        if item_cond:
-            if isinstance(item_cond, dict):
-                item_cond = [item_cond]
-            for cond in item_cond:
-                self.apply_item_condition(cond)
-        add_exit = effect.get("add_exit")
-        if add_exit:
-            if isinstance(add_exit, dict):
-                add_exit = [add_exit]
-            for cfg in add_exit:
-                room = cfg.get("room")
-                target = cfg.get("target")
-                pre = cfg.get("preconditions")
-                if room and target:
-                    self.add_exit(room, target, pre)
+    def apply_effect(
+        self, effect: list[Dict[str, Any]] | Dict[str, Any] | None
+    ) -> None:
+        if not effect:
+            return
+        if isinstance(effect, dict):
+            effect = [effect]
+        for eff in effect:
+            item_cond = eff.get("item_conditions") or eff.get("item_condition")
+            if item_cond:
+                if isinstance(item_cond, dict):
+                    item_cond = [item_cond]
+                for cond in item_cond:
+                    self.apply_item_condition(cond)
+            add_exit = eff.get("add_exit")
+            if add_exit:
+                if isinstance(add_exit, dict):
+                    add_exit = [add_exit]
+                for cfg in add_exit:
+                    room = cfg.get("room")
+                    target = cfg.get("target")
+                    pre = cfg.get("preconditions")
+                    if room and target:
+                        self.add_exit(room, target, pre)
 
     def describe_current(self, messages: Dict[str, str] | None = None) -> str:
         room = self.rooms[self.current]
@@ -507,7 +528,7 @@ class World:
         return False
 
     def add_exit(
-        self, room_id: str, target: str, pre: Dict[str, Any] | None = None
+        self, room_id: str, target: str, pre: list[Dict[str, Any]] | None = None
     ) -> None:
         room = self.rooms.setdefault(room_id, Room())
         exits = room.exits

--- a/engine/world_model.py
+++ b/engine/world_model.py
@@ -82,8 +82,8 @@ class Action:
     item: Optional[str] = None
     target_item: Optional[str] = None
     target_npc: Optional[str] = None
-    preconditions: Optional[Dict[str, Any]] = None
-    effect: Optional[Dict[str, Any]] = None
+    preconditions: Optional[list[Dict[str, Any]]] = None
+    effect: Optional[list[Dict[str, Any]]] = None
     messages: Dict[str, str] = field(default_factory=dict)
 
     def get(self, key: str, default: Any = None) -> Any:  # pragma: no cover - compat

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,18 +62,16 @@ def data_dir(tmp_path):
                 "trigger": "use",
                 "item": "sword",
                 "target_item": "gem",
-                "preconditions": {"is_location": "room2"},
-                "effect": {
-                    "item_condition": [{"item": "gem", "state": "green"}]
-                },
+                "preconditions": [{"is_location": "room2"}],
+                "effect": [{"item_conditions": [{"item": "gem", "state": "green"}]}],
             }
         },
         "start": "start",
         "endings": {
             "green_gem": {
-                "preconditions": {
-                    "item_condition": {"item": "gem", "state": "green"}
-                }
+                "preconditions": [
+                    {"item_conditions": [{"item": "gem", "state": "green"}]}
+                ]
             }
         },
     }
@@ -113,13 +111,7 @@ def data_dir(tmp_path):
                 },
             }
         },
-        "actions": {
-            "cut_gem": {
-                "messages": {
-                    "success": "The gem now gleams green."
-                }
-            }
-        },
+        "actions": {"cut_gem": {"messages": {"success": "The gem now gleams green."}}},
         "endings": {"green_gem": "The gem is green."},
     }
 
@@ -159,11 +151,7 @@ def data_dir(tmp_path):
             }
         },
         "actions": {
-            "cut_gem": {
-                "messages": {
-                    "success": "Das Juwel leuchtet jetzt grün."
-                }
-            }
+            "cut_gem": {"messages": {"success": "Das Juwel leuchtet jetzt grün."}}
         },
         "endings": {"green_gem": "Das Juwel ist grün."},
     }
@@ -179,5 +167,3 @@ def data_dir(tmp_path):
             yaml.safe_dump(data, fh)
 
     return tmp_path
-
-

--- a/tests/test_effect_item_conditions.py
+++ b/tests/test_effect_item_conditions.py
@@ -6,14 +6,15 @@ def test_apply_effect_multiple_item_conditions(data_dir):
     g = game.Game(str(data_dir / "en" / "world.yaml"), "en")
     assert "sword" in g.world.rooms["room3"]["items"]
     g.world.apply_effect(
-        {
-            "item_condition": [
-                {"item": "gem", "state": "green"},
-                {"item": "sword", "location": LocationTag.INVENTORY},
-            ]
-        }
+        [
+            {
+                "item_conditions": [
+                    {"item": "gem", "state": "green"},
+                    {"item": "sword", "location": LocationTag.INVENTORY},
+                ]
+            }
+        ]
     )
     assert g.world.item_states["gem"] == "green"
     assert "sword" in g.world.inventory
     assert "sword" not in g.world.rooms["room3"]["items"]
-

--- a/tests/test_endings.py
+++ b/tests/test_endings.py
@@ -13,10 +13,17 @@ def test_end_condition_inventory_and_location(data_dir, io_backend):
         "start": "room1",
         "endings": {
             "win": {
-                "preconditions": {
-                    "is_location": "room2",
-                    "item_condition": {"item": "crown", "location": LocationTag.INVENTORY.value},
-                }
+                "preconditions": [
+                    {"is_location": "room2"},
+                    {
+                        "item_conditions": [
+                            {
+                                "item": "crown",
+                                "location": LocationTag.INVENTORY.value,
+                            }
+                        ]
+                    },
+                ]
             }
         },
     }
@@ -48,10 +55,10 @@ def test_end_condition_inventory_lacks(data_dir, io_backend):
         "start": "room1",
         "endings": {
             "fail": {
-                "preconditions": {
-                    "is_location": "room2",
-                    "item_condition": {"item": "crown", "location": "room1"},
-                }
+                "preconditions": [
+                    {"is_location": "room2"},
+                    {"item_conditions": [{"item": "crown", "location": "room1"}]},
+                ]
             }
         },
     }
@@ -82,10 +89,10 @@ def test_end_condition_or_room_has(data_dir, io_backend):
         "start": "room1",
         "endings": {
             "done": {
-                "preconditions": {
-                    "is_location": "room2",
-                    "item_condition": {"item": "sword", "location": "room2"},
-                }
+                "preconditions": [
+                    {"is_location": "room2"},
+                    {"item_conditions": [{"item": "sword", "location": "room2"}]},
+                ]
             }
         },
     }
@@ -113,4 +120,3 @@ def test_end_condition_item_state(data_dir, io_backend):
     assert g.world.set_item_state("gem", "green")
     g._check_end()
     assert io_backend.outputs[-1] == "The gem is green."
-

--- a/tests/test_examine_action.py
+++ b/tests/test_examine_action.py
@@ -12,7 +12,13 @@ def test_examine_triggers_action(data_dir, io_backend):
         Action(
             trigger="examine",
             item="stone",
-            effect={"item_condition": {"item": "coin", "location": LocationTag.CURRENT_ROOM}},
+            effect=[
+                {
+                    "item_conditions": [
+                        {"item": "coin", "location": LocationTag.CURRENT_ROOM}
+                    ]
+                }
+            ],
             messages={"success": "You find a coin."},
         )
     )

--- a/tests/test_npcs.py
+++ b/tests/test_npcs.py
@@ -10,7 +10,11 @@ def make_world() -> World:
             "old_man": {
                 "state": "unknown",
                 "states": {"unknown": {}, "met": {}, "helped": {}},
-            }
+            },
+            "old_woman": {
+                "state": "unknown",
+                "states": {"unknown": {}, "met": {}, "helped": {}},
+            },
         },
         "rooms": {"room1": {"description": "Room 1.", "exits": {}}},
         "start": "room1",
@@ -110,7 +114,7 @@ def test_npc_event_triggered_on_start(tmp_path, monkeypatch, io_backend):
 
 def test_action_requires_npc_met():
     w = make_world()
-    pre = {"npc_met": "old_man"}
+    pre = [{"npc_met": "old_man"}]
     assert not w.check_preconditions(pre)
     w.meet_npc("old_man")
     assert w.check_preconditions(pre)
@@ -118,11 +122,27 @@ def test_action_requires_npc_met():
 
 def test_action_requires_npc_help():
     w = make_world()
-    pre_help = {"npc_help": "old_man"}
-    pre_state = {"npc_state": {"npc": "old_man", "state": StateTag.HELPED}}
+    pre_help = [{"npc_help": "old_man"}]
+    pre_state = [{"npc_state": {"npc": "old_man", "state": StateTag.HELPED}}]
     assert not w.check_preconditions(pre_help)
     assert not w.check_preconditions(pre_state)
     w.npc_states["old_man"] = StateTag.HELPED
     w.npcs["old_man"]["state"] = StateTag.HELPED
     assert w.check_preconditions(pre_help)
     assert w.check_preconditions(pre_state)
+
+
+def test_action_requires_multiple_npc_conditions():
+    w = make_world()
+    pre = [
+        {
+            "npc_conditions": [
+                {"npc": "old_man", "state": StateTag.MET},
+                {"npc": "old_woman", "state": StateTag.HELPED},
+            ]
+        }
+    ]
+    assert not w.check_preconditions(pre)
+    w.meet_npc("old_man")
+    w.set_npc_state("old_woman", StateTag.HELPED)
+    assert w.check_preconditions(pre)

--- a/tests/test_world_model.py
+++ b/tests/test_world_model.py
@@ -39,8 +39,8 @@ def test_action_dataclass():
         trigger="use",
         item="key",
         target_item="door",
-        preconditions={"is_location": "hall"},
-        effect={"item_condition": {"item": "door", "state": "open"}},
+        preconditions=[{"is_location": "hall"}],
+        effect=[{"item_conditions": [{"item": "door", "state": "open"}]}],
         messages={"success": "opened"},
     )
     assert action.trigger == "use"


### PR DESCRIPTION
## Summary
- rename `item_condition`/`npc_condition` to plural `*_conditions` in world data
- treat action preconditions and effects as lists
- update engine, integrity checks, and tests for list-based item and NPC conditions

## Testing
- `poetry run ruff format engine/integrity.py engine/world.py tests/test_npcs.py`
- `poetry run ruff check engine/integrity.py engine/world.py tests/test_npcs.py -v`
- `poetry run pyright`
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b37444af648330adce1bb699635d6f