### PR TITLE
refactor: drop redundant action mapping checks

### DIFF
--- a/engine/integrity.py
+++ b/engine/integrity.py
@@ -117,9 +117,6 @@ def validate_world_structure(w: world.World) -> List[str]:
         if target_item and target_item not in w.items:
             errors.append(f"Action references missing target item '{target_item}'")
         pre = action.get("preconditions") or {}
-        if isinstance(pre, list):
-            errors.append("Action preconditions must be a mapping")
-            pre = {}
         loc = pre.get("is_location")
         if loc and loc not in w.rooms:
             errors.append(f"Action precondition references missing room '{loc}'")
@@ -161,9 +158,6 @@ def validate_world_structure(w: world.World) -> List[str]:
                         f"Action precondition references missing state '{state_key}' for NPC '{cond_npc}'"
                     )
         eff = action.get("effect") or {}
-        if isinstance(eff, list):
-            errors.append("Action effect must be a mapping")
-            eff = {}
         conds = eff.get("item_conditions") or []
         for cond in conds:
             eff_item = cond.get("item")

--- a/engine/world.py
+++ b/engine/world.py
@@ -54,16 +54,6 @@ class World:
                 action = dict(action)
                 if "precondition" in action and "preconditions" not in action:
                     action["preconditions"] = action.pop("precondition")
-                pre = action.get("preconditions")
-                if pre is not None:
-                    if not isinstance(pre, dict):
-                        raise TypeError("preconditions must be a mapping")
-                    action["preconditions"] = pre
-                eff = action.get("effect")
-                if eff is not None:
-                    if not isinstance(eff, dict):
-                        raise TypeError("effect must be a mapping")
-                    action["effect"] = eff
             normalized.append(action)
         self.actions = [
             act if isinstance(act, Action) else Action(**act) for act in normalized
@@ -339,8 +329,6 @@ class World:
     def check_preconditions(self, pre: dict[str, Any] | None) -> bool:
         if not pre:
             return True
-        if not isinstance(pre, dict):
-            raise TypeError("preconditions must be a mapping")
         loc = pre.get("is_location")
         if loc and self.current != (loc.value if isinstance(loc, LocationTag) else loc):
             return False
@@ -413,8 +401,6 @@ class World:
     def apply_effect(self, effect: dict[str, Any] | None) -> None:
         if not effect:
             return
-        if not isinstance(effect, dict):
-            raise TypeError("effect must be a mapping")
         item_cond = effect.get("item_conditions")
         if item_cond:
             for cond in item_cond:

--- a/tests/test_action_validation.py
+++ b/tests/test_action_validation.py
@@ -1,0 +1,23 @@
+import pytest
+from pydantic import ValidationError
+
+from engine.world import World
+
+
+def make_world(action: dict):
+    data = {
+        "start": "room",
+        "rooms": {"room": {"names": ["Room"], "description": ""}},
+        "actions": [action],
+    }
+    return World(data)
+
+
+def test_invalid_action_preconditions():
+    with pytest.raises(ValidationError):
+        make_world({"preconditions": []})
+
+
+def test_invalid_action_effect():
+    with pytest.raises(ValidationError):
+        make_world({"effect": []})


### PR DESCRIPTION
## Summary
- rely on Pydantic to validate action preconditions and effects
- simplify `check_preconditions` and `apply_effect`
- streamline world integrity validation
- cover invalid action definitions in tests

## Testing
- `poetry run ruff check .`
- `poetry run pyright` *(fails: Import "pydantic" could not be resolved)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*

------
https://chatgpt.com/codex/tasks/task_e_68b3e54c65dc833092a101ef29ece05b