### PR TITLE
refactor: enforce mandatory model fields

### DIFF
--- a/engine/integrity.py
+++ b/engine/integrity.py
@@ -105,21 +105,22 @@ def validate_world_structure(w: world.World) -> List[str]:
 
     # Actions ----------------------------------------------------------------
     for action in w.actions:
-        trigger = action.get("trigger")
-        if not trigger:
-            errors.append(f"Action '{action}' missing trigger")
-        if trigger != "use":
+        if action.trigger != "use":
             continue
         item = action.get("item")
-        if item and item not in w.items:
+        if item not in w.items:
             errors.append(f"Action '{action}' references missing item '{item}'")
         target_item = action.get("target_item")
         if target_item and target_item not in w.items:
-            errors.append(f"Action '{action}' references missing target item '{target_item}'")
+            errors.append(
+                f"Action '{action}' references missing target item '{target_item}'"
+            )
         pre = action.get("preconditions") or {}
         loc = pre.get("is_location")
         if loc and loc not in w.rooms:
-            errors.append(f"Action '{action}' precondition references missing room '{loc}'")
+            errors.append(
+                f"Action '{action}' precondition references missing room '{loc}'"
+            )
         conds = pre.get("item_conditions") or []
         for cond in conds:
             cond_item = cond.get("item")
@@ -162,7 +163,9 @@ def validate_world_structure(w: world.World) -> List[str]:
         for cond in conds:
             eff_item = cond.get("item")
             if eff_item and eff_item not in w.items:
-                errors.append(f"Action '{action}' effect references missing item '{eff_item}'")
+                errors.append(
+                    f"Action '{action}' effect references missing item '{eff_item}'"
+                )
             eff_state = cond.get("state")
             if (
                 eff_item
@@ -190,7 +193,9 @@ def validate_world_structure(w: world.World) -> List[str]:
         for cond in npc_conds:
             cond_npc = cond.get("npc")
             if cond_npc and cond_npc not in w.npcs:
-                errors.append(f"Action '{action}' effect references missing NPC '{cond_npc}'")
+                errors.append(
+                    f"Action '{action}' effect references missing NPC '{cond_npc}'"
+                )
             cond_state = cond.get("state")
             if cond_npc and cond_state:
                 state_key = (
@@ -229,7 +234,9 @@ def validate_world_structure(w: world.World) -> List[str]:
             pre = cfg.get("preconditions")
             if pre is not None:
                 if isinstance(pre, list):
-                    errors.append("Action '{action}' effect exit precondition must be a mapping")
+                    errors.append(
+                        "Action '{action}' effect exit precondition must be a mapping"
+                    )
                     pre = None
                 if pre:
                     loc = pre.get("is_location")

--- a/engine/world.py
+++ b/engine/world.py
@@ -381,7 +381,7 @@ class World:
                 self.debug(f"inventory {self.inventory}")
             else:
                 room_id = location
-                room = self.rooms.setdefault(room_id, Room())
+                room = self.rooms.setdefault(room_id, Room(names=[], description=""))
                 room.items.append(item_id)
                 self.debug(f"room {room_id} items {room.items}")
 
@@ -515,7 +515,7 @@ class World:
     def add_exit(
         self, room_id: str, target: str, pre: dict[str, Any] | None = None
     ) -> None:
-        room = self.rooms.setdefault(room_id, Room())
+        room = self.rooms.setdefault(room_id, Room(names=[], description=""))
         exits = room.exits
         target_room = self.rooms.get(target)
         names = target_room.names if target_room else [target]
@@ -532,7 +532,7 @@ class World:
         items = room.items
         item_name_cf = item_name.casefold()
         for item_id in list(items):
-            names = self.items.get(item_id, Item()).names
+            names = self.items.get(item_id, Item(names=[], description="")).names
             if any(name.casefold() == item_name_cf for name in names):
                 items.remove(item_id)
                 self.inventory.append(item_id)
@@ -546,7 +546,7 @@ class World:
     def drop(self, item_name: str) -> bool:
         item_name_cf = item_name.casefold()
         for item_id in list(self.inventory):
-            names = self.items.get(item_id, Item()).names
+            names = self.items.get(item_id, Item(names=[], description="")).names
             if any(name.casefold() == item_name_cf for name in names):
                 self.inventory.remove(item_id)
                 room = self.rooms[self.current]
@@ -557,7 +557,7 @@ class World:
         return False
 
     def add_npc_to_location(self, npc_id: str, location: str) -> None:
-        room = self.rooms.setdefault(location, Room())
+        room = self.rooms.setdefault(location, Room(names=[], description=""))
         if npc_id not in room.occupants:
             room.occupants.append(npc_id)
 

--- a/engine/world_model.py
+++ b/engine/world_model.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -19,8 +19,8 @@ class StateTag(Enum):
 
 
 class Room(BaseModel):
-    names: List[str] = Field(default_factory=list)
-    description: str = ""
+    names: List[str]
+    description: str
     items: List[str] = Field(default_factory=list)
     exits: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     occupants: List[str] = Field(default_factory=list)
@@ -45,9 +45,9 @@ class Room(BaseModel):
 
 
 class Item(BaseModel):
-    names: List[str] = Field(default_factory=list)
-    description: str = ""
-    state: Optional[str | StateTag] = None
+    names: List[str]
+    description: str | None = None
+    state: str | StateTag | None = None
     states: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
 
     model_config = ConfigDict(extra="forbid")
@@ -63,8 +63,8 @@ class Item(BaseModel):
 
 
 class Npc(BaseModel):
-    names: List[str] = Field(default_factory=list)
-    state: Optional[str | StateTag] = None
+    names: List[str]
+    state: str | StateTag | None = None
     states: Dict[str, Dict[str, Any]] = Field(default_factory=dict)
     meet: Dict[str, Any] = Field(default_factory=dict)
 
@@ -81,12 +81,12 @@ class Npc(BaseModel):
 
 
 class Action(BaseModel):
-    trigger: Optional[str] = None
-    item: Optional[str] = None
-    target_item: Optional[str] = None
-    target_npc: Optional[str] = None
-    preconditions: Optional[Dict[str, Any]] = None
-    effect: Optional[Dict[str, Any]] = None
+    trigger: str
+    item: str
+    target_item: str | None = None
+    target_npc: str | None = None
+    preconditions: Dict[str, Any] | None = None
+    effect: Dict[str, Any] | None = None
     messages: Dict[str, str] = Field(default_factory=dict)
 
     model_config = ConfigDict(extra="forbid")

--- a/tests/test_item_states.py
+++ b/tests/test_item_states.py
@@ -16,7 +16,12 @@ def make_world() -> World:
             }
         },
         "rooms": {
-            "room1": {"description": "Room 1.", "items": ["crown"], "exits": {}}
+            "room1": {
+                "names": ["Room 1"],
+                "description": "Room 1.",
+                "items": ["crown"],
+                "exits": {},
+            }
         },
         "start": "room1",
     }
@@ -52,8 +57,12 @@ def test_item_state_saved_and_loaded(tmp_path):
         ("de", "Juwel", "ein rotes juwel.", "ein grünes juwel.", "Raum 2"),
     ],
 )
-def test_states_from_files(data_dir, language, item_name, dull_phrase, sharp_phrase, exit_name):
-    w = World.from_files(data_dir / "generic/world.yaml", data_dir / f"{language}/world.yaml")
+def test_states_from_files(
+    data_dir, language, item_name, dull_phrase, sharp_phrase, exit_name
+):
+    w = World.from_files(
+        data_dir / "generic/world.yaml", data_dir / f"{language}/world.yaml"
+    )
     assert w.item_states["gem"] == "red"
     assert w.move(exit_name)
     desc = w.describe_item(item_name)

--- a/tests/test_npcs.py
+++ b/tests/test_npcs.py
@@ -8,15 +8,23 @@ def make_world() -> World:
     data = {
         "npcs": {
             "old_man": {
+                "names": ["Old Man"],
                 "state": "unknown",
                 "states": {"unknown": {}, "met": {}, "helped": {}},
             },
             "old_woman": {
+                "names": ["Old Woman"],
                 "state": "unknown",
                 "states": {"unknown": {}, "met": {}, "helped": {}},
             },
         },
-        "rooms": {"room1": {"description": "Room 1.", "exits": {}}},
+        "rooms": {
+            "room1": {
+                "names": ["Room 1"],
+                "description": "Room 1.",
+                "exits": {},
+            }
+        },
         "start": "room1",
     }
     return World(data)
@@ -86,6 +94,7 @@ def test_npc_event_triggered_on_start(tmp_path, monkeypatch, io_backend):
         "start": "room1",
         "npcs": {
             "old_man": {
+                "names": ["Old Man"],
                 "state": "unknown",
                 "states": {"unknown": {}, "met": {}},
                 "meet": {"location": "room1"},

--- a/tests/test_save_state_inventory.py
+++ b/tests/test_save_state_inventory.py
@@ -10,15 +10,18 @@ def make_world() -> World:
         },
         "rooms": {
             "room1": {
+                "names": ["Room 1"],
                 "description": "Room 1.",
                 "exits": {"room2": ["Room 2"], "room3": ["Room 3"]},
             },
             "room2": {
+                "names": ["Room 2"],
                 "description": "Room 2.",
                 "items": ["sword"],
                 "exits": {"room1": ["Room 1"], "room3": ["Room 3"]},
             },
             "room3": {
+                "names": ["Room 3"],
                 "description": "Room 3.",
                 "items": ["crown"],
                 "exits": {"room1": ["Room 1"], "room2": ["Room 2"]},


### PR DESCRIPTION
## Summary
- enforce required fields for rooms, items, NPCs and actions in world model
- simplify action integrity checks to rely on model validation
- update world helpers and tests for new mandatory fields

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .`
- `poetry run pyright` *(fails: Import "pydantic" could not be resolved)*
- `poetry run pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic')*


------
https://chatgpt.com/codex/tasks/task_e_68b3f761a7fc8330b0c96c1e8e633184