### PR TITLE
chore: configure ruff and pyright

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,23 @@ ruff = "*"
 [tool.poetry.scripts]
 "herrschaft-der-asche" = "game.main:run_cli"
 
+[tool.ruff]
+line-length = 140
+target-version = "py312"
+src = ["engine", "game", "tests"]
+
+[tool.ruff.lint]
+select = [
+  "E", "F", "B", "I", "C4", "N", "Q", "S", "YTT", "DTZ", "UP", "SIM", "ARG"
+]
+
+[tool.pyright]
+include = ["engine", "game", "tests"]
+pythonVersion = "3.12"
+typeCheckingMode = "strict"
+reportMissingImports = true
+reportUnusedImport = true
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
- configure ruff with extended lint rules and 140 character line length
- enable strict type checking via pyright

## Testing
- `poetry run ruff format .`
- `poetry run ruff check .` (fails: found lint errors)
- `poetry run pyright` (fails: reported type errors)
- `poetry run pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b447ac34d483308c210fe86b9cd28c