### PR TITLE
feat: add branching dialog system

### DIFF
--- a/data/de/world.de.yaml
+++ b/data/de/world.de.yaml
@@ -73,11 +73,21 @@ npcs:
       met:
         text: "Marek wartet, den Blick immer wieder zum Horizont gerichtet, wo der Wind die Asche in Wellen treibt."
         examine: "Mareks Mantel ist mit einem feinen Staub aus Asche überzogen; feine Narben ziehen sich über seine Knöchel. Unter dem Ruß glimmt sein Blick wie eine beharrliche Glut. Er steht mit der Geduld eines Mannes, der viele Winter abgewartet hat."
-        talk: "'Bring die Aschenkrone ins Dorf', sagt Marek leise, als wolle er die Asche nicht wecken. 'Im Wald lebt der Einsiedler Ashram – er liest Spuren, wo andere nur Staub sehen. Er wird dir helfen.'"
       helped:
         text: "Marek begrüßt dich mit einem echten Lächeln, das in dieser grauen Welt selten ist."
         examine: "Erleichterung liegt auf Mareks Schultern wie ein abgelegter Mantel. In seinem Haar zeigt die Asche silberne Fäden, und seine Hände sind ruhig – nicht mehr um alte Sorgen gekrampft."
-        talk: "Marek nickt. 'Vergiss die Krone nicht. Jeder Schritt mit ihr lässt die Asche ein wenig leichter fallen.'"
+    dialog:
+      start:
+        text: "Marek mustert dich. Was willst du wissen?"
+        options:
+          past: "Erzähl mir von der Vergangenheit."
+          ashen_crown: "Was hat es mit der Aschenkrone auf sich?"
+      past:
+        text: "Er spricht von Tagen vor der Asche, von grünen Feldern und verlorenen Hoffnungen."
+        options:
+          ashen_crown: "Was hat es mit der Aschenkrone auf sich?"
+      quest:
+        text: "'Bring die Aschenkrone ins Dorf', sagt Marek leise, als wolle er die Asche nicht wecken. 'Im Wald lebt der Einsiedler Ashram – er liest Spuren, wo andere nur Staub sehen. Er wird dir helfen.'"
   ashram:
     names:
       - Ashram
@@ -87,11 +97,16 @@ npcs:
       met:
         text: "Ashram mustert dich, als lese er das Wetter in deinem Gesicht."
         examine: "Seine Gewänder duften nach Thymian und Rauch. Kreidestaub schimmert an seinen Fingerspitzen, und feine Zeichen säumen den Schaft seines Stabes. Seine Ruhe trägt die Schwere alter Karten."
-        talk: "Er hört dir zu, ohne zu unterbrechen, und seine fingerlangen Kreidespuren verraten einen, der Zeichen zu lesen weiß. 'Bringe mir, was du nicht entziffern kannst', sagt er. 'Die Asche schreibt in feinen Linien.'"
       helped:
         text: "Ashram nickt, in seinen Augen glimmt es, als hätte jemand eine Glut geschürt."
         examine: "Die Falten in seinen Augenwinkeln glätten sich, als hätte sich eine lange Sorge gelöst. Am Stab ist eine neue Kerbe: eine leise Zählmarke für einen beglichenen Dienst."
-        talk: "'Zeig mir, was der Staub verschluckt hat', sagt er. 'Gemeinsam holen wir die Schrift wieder an die Oberfläche.'"
+    dialog:
+      start:
+        text: "Ashram schaut dich ruhig an."
+        options:
+          goal: "Ich suche die Ruinen."
+      goal:
+        text: "'Zeig mir die Karte', sagt Ashram."
 
 actions:
   open_chest:

--- a/data/en/world.en.yaml
+++ b/data/en/world.en.yaml
@@ -73,11 +73,21 @@ npcs:
       met:
         text: "Marek waits, his gaze straying to the horizon where the wind combs ash into waves."
         examine: "Marek's coat is salted with ash; scars web his knuckles. Under the soot his eyes hold a steady ember. He stands with the patience of someone who has waited through many winters."
-        talk: "'Bring the Ashen Crown to the village,' Marek says softly, as if not to wake the dust. 'In the forest lives Ashram the hermit—he reads signs where others see only soot. He will help you.'"
       helped:
         text: "Marek greets you with a rare, unguarded smile."
         examine: "Relief sits on Marek's shoulders like a cloak set down. The ash in his hair shows silver threads, and his hands are steady now, no longer clenched around old fears."
-        talk: "Marek nods. 'Don't forget the crown. Each step with it makes the ash fall a little lighter.'"
+    dialog:
+      start:
+        text: "Marek studies you. What do you want to know?"
+        options:
+          past: "Tell me about the past."
+          ashen_crown: "What about the Ashen Crown?"
+      past:
+        text: "He tells of days before the ash, of green fields and promises lost."
+        options:
+          ashen_crown: "What about the Ashen Crown?"
+      quest:
+        text: "'Bring the Ashen Crown to the village,' Marek says softly, as if not to wake the dust. 'In the forest lives Ashram the hermit—he reads signs where others see only soot. He will help you.'"
   ashram:
     names:
       - Ashram
@@ -87,11 +97,16 @@ npcs:
       met:
         text: "Ashram studies you as if reading the weather from your face."
         examine: "Ashram's robes smell of thyme and smoke. Chalk dust marks his fingertips, and faint sigils line the haft of his walking stick. His calm carries the weight of old maps."
-        talk: "He listens without interruption; chalk-dusted fingers betray a reader of signs. 'Bring me what you cannot decipher,' he says. 'Ash writes in fine lines.'"
       helped:
         text: "Ashram nods; a spark glows in his eyes as if a coal were stirred."
         examine: "The lines at the corners of Ashram's eyes ease, as if a long-held concern has softened. His staff bears a new notch, a small tally in a quiet ledger of favors repaid."
-        talk: "'Show me what the dust has swallowed,' he says. 'Together we'll draw the words back to the surface.'"
+    dialog:
+      start:
+        text: "Ashram's gaze rests on you."
+        options:
+          goal: "I seek the ruins."
+      goal:
+        text: "'Show me the map,' Ashram says."
 
 actions:
   open_chest:

--- a/data/generic/world.yaml
+++ b/data/generic/world.yaml
@@ -48,6 +48,20 @@ npcs:
       helped: {}
     meet:
       location: ash_village
+    dialog:
+      start:
+        options:
+          - id: past
+            next: past
+          - id: ashen_crown
+            next: quest
+      past:
+        options:
+          - id: ashen_crown
+            next: quest
+      quest:
+        effect:
+          set_npc_state: helped
   ashram:
     state: unknown
     states:
@@ -60,6 +74,14 @@ npcs:
         npc_conditions:
           - npc: villager
             state: helped
+    dialog:
+      start:
+        options:
+          - id: goal
+            next: goal
+      goal:
+        effect:
+          set_npc_state: helped
 
 actions:
   interpret_map:

--- a/engine/llm.py
+++ b/engine/llm.py
@@ -253,7 +253,7 @@ class OllamaLLM(LLMBackend):
         v_cf = v.casefold()
         # look -> examine when an object is present
         if v_cf == "look" and o:
-            return "examine", o, None if not b else b
+            return "examine", o, b if b else None
         # open-like verbs -> use, swap order (tool first)
         if v_cf in {"open", "öffne", "öffnen"}:
             if o and b:

--- a/engine/world.py
+++ b/engine/world.py
@@ -223,6 +223,25 @@ class World:
             for key, value in npc_data.items():
                 if key == "states":
                     continue
+                if key == "dialog" and isinstance(value, dict):
+                    base_dialog = npc_cfg.setdefault("dialog", {})
+                    for node_id, node_cfg in value.items():
+                        base_node = base_dialog.setdefault(node_id, {})
+                        text = node_cfg.get("text")
+                        if text is not None:
+                            base_node["text"] = text
+                        lang_opts = node_cfg.get("options")
+                        if isinstance(lang_opts, dict):
+                            base_opts = base_node.setdefault("options", [])
+                            if base_opts:
+                                for opt in base_opts:
+                                    opt_id = opt.get("id")
+                                    if opt_id and opt_id in lang_opts:
+                                        opt["prompt"] = lang_opts[opt_id]
+                            else:
+                                for opt_id, prompt in lang_opts.items():
+                                    base_opts.append({"id": opt_id, "prompt": prompt})
+                    continue
                 if isinstance(value, dict):
                     npc_cfg.setdefault(key, {}).update(value)
                 else:

--- a/engine/world_model.py
+++ b/engine/world_model.py
@@ -68,11 +68,25 @@ class Item(BaseModel):
         setattr(self, key, value)
 
 
+class DialogOption(BaseModel):
+    id: str
+    prompt: str | None = None
+    next: str | None = None
+    effect: dict[str, Any] | None = None
+
+
+class DialogNode(BaseModel):
+    text: str | None = None
+    options: list[DialogOption] = Field(default_factory=list)
+    effect: dict[str, Any] | None = None
+
+
 class Npc(BaseModel):
     names: list[str]
     state: str | StateTag | None = None
     states: dict[str, dict[str, Any]] = Field(default_factory=dict)  # noqa
     meet: dict[str, Any] = Field(default_factory=dict)  # noqa
+    dialog: dict[str, DialogNode] = Field(default_factory=dict)  # noqa
 
     model_config = ConfigDict(extra="forbid")
 
@@ -114,6 +128,8 @@ __all__ = [
     "CommandCategory",
     "Room",
     "Item",
+    "DialogOption",
+    "DialogNode",
     "Npc",
     "Action",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,6 +58,10 @@ def data_dir(tmp_path):
                 "state": "unknown",
                 "states": {"unknown": {}, "met": {}, "helped": {}},
                 "meet": {"location": "room2"},
+                "dialog": {
+                    "start": {"options": [{"id": "quest", "next": "quest"}]},
+                    "quest": {"effect": {"set_npc_state": "helped"}},
+                },
             }
         },
         "actions": {
@@ -97,13 +101,16 @@ def data_dir(tmp_path):
                 "names": ["Old Man"],
                 "meet": {"text": "The old man greets you."},
                 "states": {
-                    "met": {
-                        "text": "The old man nods at you.",
-                        "talk": "You tell the old man about your quest. He agrees to help.",
+                    "met": {"text": "The old man nods at you."},
+                    "helped": {"text": "The old man smiles at you."},
+                },
+                "dialog": {
+                    "start": {
+                        "text": "The old man peers at you.",
+                        "options": {"quest": "I need your help."},
                     },
-                    "helped": {
-                        "text": "The old man smiles at you.",
-                        "talk": "The old man has already offered his aid.",
+                    "quest": {
+                        "text": "You tell the old man about your quest. He agrees to help.",
                     },
                 },
             }
@@ -136,13 +143,16 @@ def data_dir(tmp_path):
                 "names": ["Alter Mann"],
                 "meet": {"text": "Der alte Mann grüßt dich."},
                 "states": {
-                    "met": {
-                        "text": "Der alte Mann nickt dir zu.",
-                        "talk": "Du erzählst dem alten Mann von deiner Suche. Er hilft dir.",
+                    "met": {"text": "Der alte Mann nickt dir zu."},
+                    "helped": {"text": "Der alte Mann lächelt dich an."},
+                },
+                "dialog": {
+                    "start": {
+                        "text": "Der alte Mann mustert dich.",
+                        "options": {"quest": "Ich brauche deine Hilfe."},
                     },
-                    "helped": {
-                        "text": "Der alte Mann lächelt dich an.",
-                        "talk": "Der alte Mann hat dir bereits geholfen.",
+                    "quest": {
+                        "text": "Du erzählst dem alten Mann von deiner Suche. Er hilft dir.",
                     },
                 },
             }

--- a/tests/story/test_story.py
+++ b/tests/story/test_story.py
@@ -27,9 +27,11 @@ def test_ruins_inaccessible_without_map(data_dir, io_backend):
     assert io_backend.outputs[-1] == g.language_manager.messages["cannot_move"]
 
     g.command_processor.cmd_go("Ash Village")
+    io_backend.inputs = ["2"]
     g.command_processor.cmd_talk("Villager")
     g.command_processor.cmd_take("Map Fragment")
     g.command_processor.cmd_go("Forest")
+    io_backend.inputs = ["1"]
     g.command_processor.cmd_talk("Ashram")
     g.command_processor.cmd_show("Map Fragment", "Ashram")
     # Optionally examine the map after interpretation (align with current story flow)
@@ -87,10 +89,10 @@ def test_game_reaches_ending(data_dir, io_backend):
         lambda: cp.cmd_take("Small Key"),
         lambda: cp.cmd_go("Forest"),
         lambda: cp.cmd_go("Ash Village"),
-        lambda: cp.cmd_talk("Villager"),
+        lambda: (io_backend.inputs.extend(["2"]), cp.cmd_talk("Villager"))[1],
         lambda: cp.cmd_take("Map Fragment"),
         lambda: cp.cmd_go("Forest"),
-        lambda: cp.cmd_talk("Ashram"),
+        lambda: (io_backend.inputs.extend(["1"]), cp.cmd_talk("Ashram"))[1],
         lambda: cp.cmd_show("Map Fragment", "Ashram"),
         # Optionally examine the map after interpretation
         lambda: cp.cmd_examine("Map Fragment"),

--- a/tests/unit/test_talk_command.py
+++ b/tests/unit/test_talk_command.py
@@ -2,22 +2,17 @@ from engine import game
 from engine.world_model import StateTag
 
 
-def test_talk_requires_npc_name(data_dir, capsys):
-    g = game.Game(str(data_dir / "en" / "world.en.yaml"), "en")
+def test_talk_requires_npc_name(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.en.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_go("Room 2")
-    capsys.readouterr()
     ok = g.command_processor.cmd_talk("")
     assert ok is False
 
 
-def test_talk_changes_state_and_outputs_text(data_dir, capsys):
-    g = game.Game(str(data_dir / "en" / "world.en.yaml"), "en")
+def test_talk_dialog_sets_state(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.en.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_go("Room 2")
-    capsys.readouterr()
+    io_backend.inputs = ["1"]
     g.command_processor.cmd_talk("Old Man")
-    out = capsys.readouterr().out
-    assert "You tell the old man about your quest. He agrees to help." in out
+    assert "You tell the old man about your quest. He agrees to help." in io_backend.outputs
     assert g.world.npc_state("old_man") == StateTag.HELPED
-    g.command_processor.cmd_talk("Old Man")
-    out = capsys.readouterr().out
-    assert "The old man has already offered his aid." in out


### PR DESCRIPTION
## Summary
- add dialog tree data model and processing for talk command
- define Marek and Ashram conversations in world and translations
- cover dialog interactions in unit and story tests

## Testing
- `pytest`
- `make all` *(failed: nodeenv failed; for more reliable node.js binaries try `pip install pyright[nodejs]`)*

------
https://chatgpt.com/codex/tasks/task_e_68ba036bb9988330945955dbd1f25776