### PR TITLE
refactor: externalize LLM open verbs

### DIFF
--- a/data/de/commands.de.yaml
+++ b/data/de/commands.de.yaml
@@ -66,3 +66,7 @@ show_log:
   - 'verlauf $a'
   - 'show_log'
   - 'show_log $a'
+llm_open_verbs:
+  - 'open'
+  - 'öffne'
+  - 'öffnen'

--- a/data/de/commands.yaml
+++ b/data/de/commands.yaml
@@ -56,4 +56,8 @@ show:
 show_log:
   - 'show_log'
   - 'show_log $a'
+llm_open_verbs:
+  - 'open'
+  - 'öffne'
+  - 'öffnen'
 

--- a/data/en/commands.en.yaml
+++ b/data/en/commands.en.yaml
@@ -68,3 +68,5 @@ show_log:
   - 'history $a'
   - 'show_log'
   - 'show_log $a'
+llm_open_verbs:
+  - 'open'

--- a/data/en/commands.yaml
+++ b/data/en/commands.yaml
@@ -59,4 +59,6 @@ show:
 show_log:
   - 'show_log'
   - 'show_log $a'
+llm_open_verbs:
+  - 'open'
 

--- a/engine/game.py
+++ b/engine/game.py
@@ -12,7 +12,7 @@ from .commands import CommandProcessor
 from .interfaces import IOBackend, LLMBackend
 from .io import ConsoleIO
 from .language import LanguageManager
-from .llm import NoOpLLM
+from .llm import SUGGEST_PREFIX, UNKNOWN_TOKEN, NoOpLLM
 from .persistence import SaveManager
 from .world_model import StateTag
 
@@ -166,11 +166,11 @@ class Game:
                 if self.command_processor.execute(normalized):
                     continue
                 mapped = self.llm.interpret(user_input)
-                if mapped == "__UNKNOWN__":
+                if mapped == UNKNOWN_TOKEN:
                     self.io.output(self.language_manager.messages["unknown_command"])
                     continue
-                if mapped.startswith("__SUGGEST__ "):
-                    suggestion = mapped[len("__SUGGEST__ ") :].strip()
+                if mapped.startswith(f"{SUGGEST_PREFIX} "):
+                    suggestion = mapped[len(SUGGEST_PREFIX) + 1 :].strip()
                     msg_tpl = self.language_manager.messages.get("llm_suggest", "Try: {command}")
                     self.io.output(msg_tpl.format(command=suggestion))
                     continue

--- a/engine/integrity.py
+++ b/engine/integrity.py
@@ -43,6 +43,8 @@ def check_translations(language: str, data_dir: Path) -> list[str]:
             if key not in lang_cmds:
                 warnings.append(f"Missing translation for command '{key}'")
         for key in lang_cmds:
+            if key.startswith("llm_"):
+                continue
             if key not in base_cmd_keys:
                 warnings.append(f"Unused command translation '{key}' ignored")
 

--- a/tests/unit/test_llm_open_verbs.py
+++ b/tests/unit/test_llm_open_verbs.py
@@ -1,0 +1,21 @@
+"""Tests for language-based open verb normalization in the LLM."""
+
+from engine import world
+from engine.language import LanguageManager
+from engine.llm import OllamaLLM
+from tests.conftest import DummyIO
+
+
+def test_open_like_verbs_use_language(data_dir):
+    """Open verbs defined in translations map to the 'use' command."""
+
+    generic = data_dir / "generic" / "world.yaml"
+    lang_world = data_dir / "en" / "world.en.yaml"
+    w = world.World.from_files(generic, lang_world)
+    lm = LanguageManager(data_dir, "de", DummyIO())
+    llm = OllamaLLM()
+    llm.set_context(w, lm, [])
+
+    verb, obj, add = llm._normalize_mapping("öffne", "Kiste", "Schlüssel")
+
+    assert (verb, obj, add) == ("use", "Schlüssel", "Kiste")


### PR DESCRIPTION
## Summary
- move LLM open-verb mapping into language files
- add constants and enum for LLM confidence and suggestion markers
- reuse constants in game loop and integrity check
- cover language-based open verbs with unit test

## Testing
- `make all`

------
https://chatgpt.com/codex/tasks/task_e_68ba732fc64c83308ef46681b656d050