### PR TITLE
refactor: use llm_config ignore settings

### DIFF
--- a/tests/unit/test_command_llm_config.py
+++ b/tests/unit/test_command_llm_config.py
@@ -1,0 +1,22 @@
+from engine import commands, language, persistence, world
+
+
+def test_command_processor_uses_llm_config(data_dir, io_backend, tmp_path):
+    generic = data_dir / "generic" / "world.yaml"
+    en = data_dir / "en" / "world.en.yaml"
+    w = world.World.from_files(generic, en)
+    lm = language.LanguageManager(data_dir, "en", io_backend)
+    lm.llm_config = {"ignore_articles": ["zzz"], "ignore_contractions": ["yyy"]}
+    saver = persistence.SaveManager(tmp_path)
+    cp = commands.CommandProcessor(
+        w,
+        lm,
+        saver,
+        lambda: None,
+        lambda: None,
+        lambda: None,
+        lambda _w: None,
+        io_backend,
+    )
+    assert cp._ignore_articles == {"zzz"}
+    assert cp._ignore_contractions == {"yyy"}


### PR DESCRIPTION
## Summary
- load ignore tokens directly from `LanguageManager.llm_config`
- drop language-specific fallback lists
- test command processor respect runtime llm config

## Testing
- `make all`


------
https://chatgpt.com/codex/tasks/task_e_68ba971e2a288330b7d4bf0acac6ddce