### PR TITLE
validate llm config fields and align llm prompt tests

### DIFF
--- a/engine/i18n.py
+++ b/engine/i18n.py
@@ -34,7 +34,29 @@ def load_commands(language: str, io: IOBackend) -> dict[str, str | list[str]]:
 def load_llm_config(language: str, io: IOBackend) -> dict:
     """Load LLM configuration for the given language code."""
     path = Path(__file__).resolve().parent.parent / "data" / language / f"llm.{language}.yaml"
-    return _load_yaml(path, io) or {}
+    data = _load_yaml(path, io) or {}
+    required = [
+        "prompt",
+        "context",
+        "guidance",
+        "ignore_articles",
+        "ignore_contractions",
+        "second_object_preps",
+    ]
+    must_have_content = [
+        "prompt",
+        "context",
+        "guidance",
+        "ignore_articles",
+        "second_object_preps",
+    ]
+    missing = [key for key in required if key not in data]
+    empty = [key for key in must_have_content if not data.get(key)]
+    if missing or empty:
+        fields = missing + empty
+        io.output(f"ERROR: Missing or empty fields {fields} in '{path.name}'")
+        raise SystemExit
+    return data
 
 
 def load_command_info(io: IOBackend) -> dict[str, dict[str, int]]:

--- a/tests/unit/test_llm_backend.py
+++ b/tests/unit/test_llm_backend.py
@@ -42,10 +42,11 @@ def test_ollama_llm_builds_context(monkeypatch, data_dir):
     llm.interpret("look around")
 
     system_prompt = captured["json"]["messages"][0]["content"]
+    first_line = lm.llm_config["prompt"].splitlines()[0]
+    assert first_line in system_prompt
     assert "Room 1." in system_prompt
     assert "Old Man" in system_prompt
     assert "red" in system_prompt
-    assert "look" in system_prompt
 
 
 def test_ollama_llm_fallback(monkeypatch, data_dir):

--- a/tests/unit/test_llm_config_errors.py
+++ b/tests/unit/test_llm_config_errors.py
@@ -1,0 +1,51 @@
+"""Validation tests for LLM configuration files."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+from engine import i18n
+
+
+def _prepare_i18n(monkeypatch, data_dir):
+    engine_dir = data_dir / "engine"
+    engine_dir.mkdir()
+    monkeypatch.setattr(i18n, "__file__", str(engine_dir / "i18n.py"))
+
+
+def test_load_llm_config_missing_field(data_dir, monkeypatch, io_backend):
+    _prepare_i18n(monkeypatch, data_dir)
+    path = data_dir / "data" / "en"
+    path.mkdir(parents=True)
+    cfg = {
+        "context": "ctx",
+        "guidance": "guide",
+        "ignore_articles": ["the"],
+        "ignore_contractions": [],
+        "second_object_preps": ["with"],
+    }
+    with open(path / "llm.en.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(cfg, fh)
+    with pytest.raises(SystemExit):
+        i18n.load_llm_config("en", io_backend)
+    assert any("Missing or empty fields" in o for o in io_backend.outputs)
+
+
+def test_load_llm_config_empty_field(data_dir, monkeypatch, io_backend):
+    _prepare_i18n(monkeypatch, data_dir)
+    path = data_dir / "data" / "en"
+    path.mkdir(parents=True)
+    cfg = {
+        "prompt": "",
+        "context": "ctx",
+        "guidance": "guide",
+        "ignore_articles": ["the"],
+        "ignore_contractions": [],
+        "second_object_preps": ["with"],
+    }
+    with open(path / "llm.en.yaml", "w", encoding="utf-8") as fh:
+        yaml.safe_dump(cfg, fh)
+    with pytest.raises(SystemExit):
+        i18n.load_llm_config("en", io_backend)
+    assert any("Missing or empty fields" in o for o in io_backend.outputs)
+

--- a/tests/unit/test_llm_fallback_semantic.py
+++ b/tests/unit/test_llm_fallback_semantic.py
@@ -18,11 +18,14 @@ class MappingLLM(LLMBackend):
 
     def __init__(self, mapped: str) -> None:
         self.mapped = mapped
+        self.prompt: str | None = None
 
     def set_context(self, world, language, log) -> None:  # noqa: D401, ARG002
+        self.prompt = language.llm_config["prompt"]
         return None
 
     def interpret(self, command: str) -> str:  # noqa: D401, ARG002
+        assert self.prompt is not None
         return self.mapped
 
 
@@ -47,3 +50,4 @@ def test_llm_fallback_on_unresolvable_argument_triggers_mapping(tmp_path):
 
     assert "small_key" in g.world.inventory
     assert any("Du trägst:" in line and "Kleiner Schlüssel" in line for line in io.outputs)
+    assert llm.prompt == g.language_manager.llm_config["prompt"]


### PR DESCRIPTION
## Summary
- validate required fields in `llm.*.yaml` and raise on missing or empty values
- adapt LLM backend tests to use `LanguageManager.llm_config` prompt
- add tests ensuring invalid LLM configs trigger errors

## Testing
- `poetry run ruff check .`
- `poetry run pytest --cov --cov-branch -q tests/unit`
- `poetry run pytest -q tests/story`


------
https://chatgpt.com/codex/tasks/task_e_68ba9789a5cc8330af2396a405ca6c35