### PR TITLE
feat: add say command for dialog options

### DIFF
--- a/data/de/commands.de.yaml
+++ b/data/de/commands.de.yaml
@@ -54,6 +54,9 @@ use:
 talk:
   - 'rede mit $a'
   - 'sprich mit $a'
+say:
+  - 'sag $a'
+  - 'sage $a'
 show:
   - 'zeige $b $a'
   - 'zeige $a $b'

--- a/data/en/commands.en.yaml
+++ b/data/en/commands.en.yaml
@@ -56,6 +56,8 @@ talk:
   - 'talk with $a'
   - 'speak to $a'
   - 'speak with $a'
+say:
+  - 'say $a'
 show:
   - 'show $a to $b'
   - 'present $a to $b'

--- a/data/generic/commands.yaml
+++ b/data/generic/commands.yaml
@@ -12,5 +12,6 @@ destroy: {arguments: 1, category: actions}
 wear: {arguments: 1, category: actions}
 use: {arguments: 2, category: actions}
 talk: {arguments: 1, category: actions}
+say: {arguments: 1, category: actions}
 show: {arguments: 2, category: actions}
 show_log: {optional_arguments: 1, category: system}

--- a/tests/story/test_story.py
+++ b/tests/story/test_story.py
@@ -27,12 +27,12 @@ def test_ruins_inaccessible_without_map(data_dir, io_backend):
     assert io_backend.outputs[-1] == g.language_manager.messages["cannot_move"]
 
     g.command_processor.cmd_go("Ash Village")
-    io_backend.inputs = ["2"]
     g.command_processor.cmd_talk("Villager")
+    g.command_processor.cmd_say("ashen_crown")
     g.command_processor.cmd_take("Map Fragment")
     g.command_processor.cmd_go("Forest")
-    io_backend.inputs = ["1"]
     g.command_processor.cmd_talk("Ashram")
+    g.command_processor.cmd_say("goal")
     g.command_processor.cmd_show("Map Fragment", "Ashram")
     # Optionally examine the map after interpretation (align with current story flow)
     g.command_processor.cmd_examine("Map Fragment")
@@ -89,10 +89,10 @@ def test_game_reaches_ending(data_dir, io_backend):
         lambda: cp.cmd_take("Small Key"),
         lambda: cp.cmd_go("Forest"),
         lambda: cp.cmd_go("Ash Village"),
-        lambda: (io_backend.inputs.extend(["2"]), cp.cmd_talk("Villager"))[1],
+        lambda: (cp.cmd_talk("Villager"), cp.cmd_say("ashen_crown"))[1],
         lambda: cp.cmd_take("Map Fragment"),
         lambda: cp.cmd_go("Forest"),
-        lambda: (io_backend.inputs.extend(["1"]), cp.cmd_talk("Ashram"))[1],
+        lambda: (cp.cmd_talk("Ashram"), cp.cmd_say("goal"))[1],
         lambda: cp.cmd_show("Map Fragment", "Ashram"),
         # Optionally examine the map after interpretation
         lambda: cp.cmd_examine("Map Fragment"),

--- a/tests/unit/test_talk_command.py
+++ b/tests/unit/test_talk_command.py
@@ -12,7 +12,13 @@ def test_talk_requires_npc_name(data_dir, io_backend):
 def test_talk_dialog_sets_state(data_dir, io_backend):
     g = game.Game(str(data_dir / "en" / "world.en.yaml"), "en", io_backend=io_backend)
     g.command_processor.cmd_go("Room 2")
-    io_backend.inputs = ["1"]
     g.command_processor.cmd_talk("Old Man")
+    g.command_processor.cmd_say("quest")
     assert "You tell the old man about your quest. He agrees to help." in io_backend.outputs
     assert g.world.npc_state("old_man") == StateTag.HELPED
+
+
+def test_say_without_dialog_returns_false(data_dir, io_backend):
+    g = game.Game(str(data_dir / "en" / "world.en.yaml"), "en", io_backend=io_backend)
+    ok = g.command_processor.cmd_say("quest")
+    assert ok is False


### PR DESCRIPTION
## Summary
- add `say` command with option-based dialog progression
- move dialog effects from `talk` into new `say` command
- update language command patterns and tests

## Testing
- `make all`


------
https://chatgpt.com/codex/tasks/task_e_68babde22c6c83308b84f20b36c23f1a